### PR TITLE
chore: bootstrap nmg-sdlc steering docs via /onboard-project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# SDLC runner config
+sdlc-config.json
+.claude/sdlc-state.json

--- a/steering/product.md
+++ b/steering/product.md
@@ -1,0 +1,169 @@
+# obsidian-memory Product Steering
+
+This document defines the product vision, target users, and success metrics.
+All feature development should align with these guidelines.
+
+---
+
+## Mission
+
+**obsidian-memory makes Claude Code's memory persistent and browseable in an Obsidian vault by (1) keyword-searching the vault on every prompt and injecting matching notes as context, and (2) distilling each finished session into a dated Markdown note that links into the vault's index.**
+
+It is a single Claude Code plugin, distributed via the [nmg-plugins](https://github.com/Nunley-Media-Group/nmg-plugins) marketplace. It is not itself a marketplace.
+
+---
+
+## Target Users
+
+### Primary: Claude Code + Obsidian power user
+
+| Characteristic | Implication |
+|----------------|-------------|
+| Uses Claude Code daily across many projects | Hooks must run on every project, every session, without per-project setup |
+| Already curates an Obsidian vault as a "second brain" | Storage must be plain Markdown in a path the user controls |
+| Expects local-first, inspectable tooling | No cloud dependency; every artifact is a file the user can read, edit, or delete |
+| Values "never blocks me" over "always perfect" | Every hook must silently no-op on any failure (missing dep, missing config, disabled flag, empty input) |
+
+### Secondary: AI-tooling tinkerer
+
+| Characteristic | Implication |
+|----------------|-------------|
+| Wants hookable, plain-text memory rather than opaque server-side context | Retrieval and distillation must be replaceable script-level components |
+| Will swap ripgrep for embeddings later | RAG must be a one-script swap — no hook-wiring changes needed to upgrade retrieval |
+| Runs Claude Code on machines where `rg` may only be an editor-embedded wrapper | RAG script must fall back to POSIX `grep -r`/`find` automatically |
+
+---
+
+## Core Value Proposition
+
+1. **Zero-config cross-session memory** — once `/obsidian-memory:setup <vault>` runs, every future Claude Code session on every project benefits from RAG on the vault and auto-distilled session notes, with no per-project wiring.
+2. **Plain-Markdown, user-owned storage** — sessions land as dated Markdown files under `<vault>/claude-memory/sessions/<project-slug>/`, linked from `Index.md`. The user can read, edit, move, or delete them.
+3. **Never blocks the user** — every hook exits 0 on any failure mode (missing dep, missing config, disabled flag, empty input). A broken hook must never stop a prompt or a session from ending cleanly.
+
+---
+
+## Product Principles
+
+| Principle | Description |
+|-----------|-------------|
+| Local-first | No network calls on the hot path. The only subprocess the distill hook spawns is `claude -p`, which the user has already authenticated. |
+| Silent failure | Any script failure exits 0 with no user-visible error. Failures log to stderr for operator inspection, never to the session UI. |
+| Plain text > databases | Every artifact is a Markdown, JSON, or JSONL file at a known path. No SQLite, no embedded server. |
+| One-script swaps | Retrieval (`vault-rag.sh`) and distillation (`vault-distill.sh`) are isolated scripts. Changing retrieval from keyword to embeddings must not touch `hooks.json` or any skill. |
+| Idempotent setup | `/obsidian-memory:setup` is safe to re-run. It writes config, creates directories, and establishes symlinks only when missing. |
+
+---
+
+## Success Metrics
+
+| Metric | Target | Why It Matters |
+|--------|--------|----------------|
+| RAG relevance on prompts where vault notes exist | Relevant notes surface on ≥60% of such prompts | The RAG hook is only valuable if it actually retrieves useful context. |
+| Distillation correctness | 0 hallucinated decisions / patterns across a sampled audit of 20 session notes | Distillations are durable memory. A fabricated "decision" pollutes the vault permanently. |
+| Hook safety | 0 reports of a hook blocking a prompt or session | The "silent failure" principle is load-bearing. One blocking hook destroys user trust. |
+| Setup idempotency | `/obsidian-memory:setup` re-run 5× produces no drift in config, symlinks, or Index.md | Users re-run setup when changing vaults or machines. It must not accumulate state. |
+
+---
+
+## Feature Prioritization
+
+### Must Have (MVP — v0.1.x, shipped)
+
+- `UserPromptSubmit` keyword RAG hook with `ripgrep` + POSIX fallback
+- `SessionEnd` distillation hook writing dated Markdown + Index.md linking
+- `/obsidian-memory:setup` idempotent vault wiring (config, symlink, Index, optional MCP registration)
+- `/obsidian-memory:distill-session` manual counterpart
+- User-scope install; hooks apply to every project
+
+### Should Have (v1 MVP scope for new work)
+
+- CHANGELOG / release-automation for nmg-plugins marketplace listing
+- Health-check skill: "is my obsidian-memory setup working?" (detects missing deps, bad config, broken symlink)
+- `/obsidian-memory:teardown` or uninstall path that is the exact inverse of `setup`
+- Disable-flag UX: clear docs + a skill that toggles `rag.enabled` / `distill.enabled` without editing JSON by hand
+
+### Could Have
+
+- Embedding-based retrieval swap for `vault-rag.sh`
+- Per-project overrides (e.g., exclude a project from distillation)
+- Configurable distillation template
+- Cross-project search surface (a skill that searches all distilled sessions for a term)
+
+A `v2` milestone is deliberately not created yet — every seeded candidate is in `v1 (MVP)` until MVP scope is closed.
+
+### Won't Have (Now)
+
+- Cloud sync or hosted backend — violates local-first
+- Writing to the vault on every prompt (only SessionEnd writes) — cost and feedback-loop risk
+- A custom Obsidian plugin on the Obsidian side — the MCP server already exists
+
+---
+
+## Key User Journeys
+
+### Journey 1: First-time install
+
+```
+1. User adds the nmg-plugins marketplace and installs obsidian-memory.
+2. User runs `/obsidian-memory:setup /path/to/vault`.
+3. Setup writes config, creates claude-memory/sessions/, symlinks projects/, writes Index.md, optionally registers the MCP server.
+4. User continues normal Claude Code usage; hooks activate on the next prompt / session end.
+```
+
+### Journey 2: Prompt with relevant prior context
+
+```
+1. User submits a prompt in a project they've worked on before.
+2. UserPromptSubmit fires vault-rag.sh → keyword-matches the prompt against the vault.
+3. Top matches are wrapped in a <vault-context> block and prepended to the prompt.
+4. Claude sees the prior notes and answers with continuity.
+```
+
+### Journey 3: Session ends, distillation lands in the vault
+
+```
+1. User /exits or closes the Claude Code session.
+2. SessionEnd fires vault-distill.sh → reads the JSONL transcript, invokes `claude -p` in a nested subprocess.
+3. A note is written under <vault>/claude-memory/sessions/<project-slug>/YYYY-MM-DD-HHMMSS.md.
+4. Index.md gets a link appended.
+5. User opens Obsidian and can browse, edit, or link the distillation like any other note.
+```
+
+### Journey 4: Manual mid-session checkpoint
+
+```
+1. User hits a natural breakpoint mid-session and wants a snapshot.
+2. User runs /obsidian-memory:distill-session.
+3. The skill finds the newest JSONL under ~/.claude/projects/ and distills it identically to the SessionEnd hook.
+4. The user continues; at session end the hook will produce a second, more complete distillation.
+```
+
+---
+
+## Brand Voice
+
+| Attribute | Do | Don't |
+|-----------|-----|-------|
+| Terse | "Writes `~/.claude/obsidian-memory/config.json`." | "This plugin will carefully write a configuration file to your home directory…" |
+| Honest about limitations | "v0.1 uses keyword matching; embeddings are a later swap." | Claim semantic search or embeddings before they ship. |
+| Operator-friendly | State exact paths, exact exit codes, exact commands. | Hand-wave with "just run setup." |
+
+---
+
+## Privacy Commitment
+
+| Data | Usage | Shared |
+|------|-------|--------|
+| Prompt text (at UserPromptSubmit) | Local keyword-matched against the local vault to compose `<vault-context>`. | Never leaves the machine. |
+| Session transcript (at SessionEnd) | Read from `~/.claude/projects/**/*.jsonl`, passed to a local `claude -p` subprocess for distillation. | Goes only to the Claude CLI subprocess that the user has already authenticated. |
+| Distilled session notes | Written to the user's local Obsidian vault. | Only shared if the user syncs their vault (Obsidian Sync / iCloud / Git / etc.); not shared by this plugin. |
+| Config (`~/.claude/obsidian-memory/config.json`) | Stores vault path and enabled flags. | Local-only. |
+
+---
+
+## References
+
+- Technical spec: `steering/tech.md`
+- Code structure: `steering/structure.md`
+- Upstream marketplace: https://github.com/Nunley-Media-Group/nmg-plugins
+- Obsidian MCP server: https://github.com/iansinnott/obsidian-claude-code-mcp

--- a/steering/structure.md
+++ b/steering/structure.md
@@ -1,0 +1,261 @@
+# obsidian-memory Code Structure Steering
+
+This document defines code organization, naming conventions, and patterns.
+All code should follow these guidelines for consistency.
+
+---
+
+## Project Layout
+
+```
+obsidian-memory/
+├── .claude-plugin/
+│   └── marketplace.json               # local plugin registry (dev aid; upstream is nmg-plugins)
+├── plugins/
+│   └── obsidian-memory/
+│       ├── .claude-plugin/
+│       │   └── plugin.json            # plugin manifest (name, version, description, keywords)
+│       ├── hooks/
+│       │   └── hooks.json             # hook → script wiring (UserPromptSubmit, SessionEnd)
+│       ├── scripts/
+│       │   ├── vault-rag.sh           # UserPromptSubmit: keyword RAG → <vault-context>
+│       │   └── vault-distill.sh       # SessionEnd: distill transcript → dated vault note
+│       └── skills/
+│           ├── setup/
+│           │   └── SKILL.md           # /obsidian-memory:setup <vault-path>
+│           └── distill-session/
+│               └── SKILL.md           # /obsidian-memory:distill-session (manual checkpoint)
+├── specs/                             # nmg-sdlc specs (one dir per feature / bug)
+│   └── <feature-slug>/
+│       ├── requirements.md
+│       ├── design.md
+│       ├── tasks.md
+│       └── feature.gherkin
+├── steering/                          # THIS directory — product / tech / structure
+│   ├── product.md
+│   ├── tech.md
+│   └── structure.md
+├── tests/                             # bats + cucumber-shell
+│   ├── unit/*.bats
+│   ├── integration/*.bats
+│   ├── features/steps/*.sh            # cucumber-shell step definitions
+│   └── run-bdd.sh
+├── CHANGELOG.md                       # Keep a Changelog + Conventional Commits
+└── README.md
+```
+
+Everything under `plugins/obsidian-memory/` is what Claude Code installs. Everything at the repo root outside `plugins/` (README, CHANGELOG, specs/, steering/, tests/) is development infrastructure and is not shipped to users.
+
+---
+
+## Layer Architecture
+
+### Request / Data Flow — UserPromptSubmit
+
+```
+Claude Code prompt event
+        ↓
+┌──────────────────────┐
+│  hooks.json          │ ← declares UserPromptSubmit → scripts/vault-rag.sh
+└────────┬─────────────┘
+         ↓
+┌──────────────────────┐
+│  vault-rag.sh        │ ← reads config, runs rg/grep, composes <vault-context>
+└────────┬─────────────┘
+         ↓ stdout (hook JSON response)
+┌──────────────────────┐
+│  Claude Code         │ ← merges <vault-context> into the prompt sent to the model
+└──────────────────────┘
+```
+
+### Request / Data Flow — SessionEnd
+
+```
+Claude Code session-end event
+        ↓
+┌──────────────────────┐
+│  hooks.json          │ ← declares SessionEnd → scripts/vault-distill.sh
+└────────┬─────────────┘
+         ↓
+┌──────────────────────┐
+│  vault-distill.sh    │ ← reads newest JSONL under ~/.claude/projects/
+│                      │   spawns CLAUDECODE="" claude -p with a distillation prompt
+│                      │   writes <vault>/claude-memory/sessions/<slug>/<ts>.md
+│                      │   appends link to <vault>/claude-memory/Index.md
+└──────────────────────┘
+```
+
+### Layer Responsibilities
+
+| Layer | Does | Doesn't Do |
+|-------|------|------------|
+| `hooks.json` | Declaratively wires event → script. | Contain logic. Scripts do the work. |
+| Hook scripts (`scripts/*.sh`) | Read config, guard against missing deps/config, do the work, emit protocol-compliant stdout, exit 0. | Read user prompts from anywhere other than hook stdin/env. Interpolate prompt text into shell commands. Ever exit non-zero at the top-level. |
+| Skills (`skills/*/SKILL.md`) | Provide user-invocable commands for setup, manual distillation, health checks, teardown. | Run on every prompt — that's the hook's job. |
+| Config file | Store vault path + enable flags. | Store credentials. Store per-project state. |
+| `specs/` | Drive `/write-code` and `/verify-code`. | Get read at runtime by the plugin. Purely dev-time artifacts. |
+| `steering/` | Constrain spec writing and code generation. | Get read at runtime. Purely dev-time. |
+
+---
+
+## Naming Conventions
+
+### Bash
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Files | `kebab-case.sh` | `vault-rag.sh`, `vault-distill.sh` |
+| Functions | `lower_snake_case` | `read_config`, `emit_vault_context` |
+| Local variables | `lower_snake_case` | `local vault_path="$1"` |
+| Constants / env-like globals | `UPPER_SNAKE_CASE` | `CONFIG_PATH`, `PLUGIN_ROOT` |
+| Exit codes | `0` for every terminating path at hook level. Internal helpers may return non-zero; the top-level script translates to 0. | — |
+
+### JSON (manifests + config)
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Top-level keys | `camelCase` in Claude Code manifests; `snake_case` in internal config | `"enabled": true`, `"vault_path": "..."` |
+| File names | `kebab-case.json` | `plugin.json`, `marketplace.json`, `hooks.json`, `config.json` |
+
+### Markdown
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Steering / README / CHANGELOG | `kebab-case.md` or conventional names | `product.md`, `README.md` |
+| Spec directories | `specs/feature-<slug>/` or `specs/bug-<slug>/` | `specs/feature-health-check/` |
+| Session distillations (inside vault) | `YYYY-MM-DD-HHMMSS.md` | `2026-04-19-143022.md` |
+| Project slugs (for `sessions/<slug>/`) | `[a-z0-9-]`, collapsed, length-capped at 60 | `obsidian-memory` |
+
+---
+
+## File Templates
+
+### Hook script template (`scripts/<hook>.sh`)
+
+```bash
+#!/usr/bin/env bash
+# <hook>.sh — <one-line purpose>
+#
+# Invoked by Claude Code for the <EventName> event. Must exit 0 on every
+# terminating path; failures log to stderr and silently no-op.
+
+set -u
+
+log_err() { printf '[%s] %s\n' "$(basename "$0")" "$*" >&2; }
+trap 'log_err "failed at line $LINENO"; exit 0' ERR
+
+CONFIG="${HOME}/.claude/obsidian-memory/config.json"
+
+# Guard: missing config → silent no-op
+[ -f "$CONFIG" ] || exit 0
+
+# Guard: feature disabled → silent no-op
+enabled="$(jq -r '.<feature>.enabled // false' "$CONFIG" 2>/dev/null || echo false)"
+[ "$enabled" = "true" ] || exit 0
+
+# Guard: required deps → silent no-op
+command -v jq >/dev/null 2>&1 || { log_err "jq missing"; exit 0; }
+
+# … do the work …
+
+exit 0
+```
+
+### Skill template (`skills/<name>/SKILL.md`)
+
+```markdown
+---
+name: obsidian-memory:<name>
+description: <one-line what this skill does>
+version: 0.1.0
+---
+
+# /obsidian-memory:<name>
+
+<one-paragraph summary>
+
+## When to Use
+
+- <trigger 1>
+- <trigger 2>
+
+## When NOT to Use
+
+- <anti-trigger>
+
+## Invocation
+
+```
+/obsidian-memory:<name> <args>
+```
+
+## Behavior
+
+1. <step>
+2. <step>
+3. <step>
+
+## Idempotency
+
+<explicit statement: is this skill safe to re-run? what does re-running do?>
+
+## Error handling
+
+<what the skill does on missing config, missing vault, missing deps>
+```
+
+---
+
+## Import Order
+
+### Bash
+
+Scripts have no imports per se, but the conventional prelude is:
+
+```bash
+#!/usr/bin/env bash
+# 1. Shebang + header comment
+# 2. set -u (never set -e at hook entry points)
+# 3. trap ERR → log + exit 0
+# 4. Constants (CONFIG, PLUGIN_ROOT, etc.)
+# 5. Function definitions (pure → composed)
+# 6. Main entrypoint at the bottom
+```
+
+### JSON
+
+No import order. Field order in manifests is fixed per `tech.md`.
+
+---
+
+## Design Tokens / UI Standards
+
+Not applicable. obsidian-memory has no UI. Its "UI" is:
+
+- A `<vault-context>` block prepended to prompts (schema: opaque Markdown body; no required attributes).
+- A dated Markdown file in the vault (template: header / decisions / patterns / open threads / tags).
+- The `Index.md` file (append-only bullet list of links).
+
+---
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Problem | Solution |
+|--------------|---------|----------|
+| `set -e` at a hook's top level | Causes the hook to exit non-zero on any unexpected command failure, blocking the user. | Use `set -u` and an `ERR` trap that logs and `exit 0`. |
+| Assuming `rg` is on `PATH` inside a hook subshell | Editor-embedded ripgrep is often not exported to hook subshells. Hook silently fails on a fresh machine. | Always check `command -v rg`, fall back to POSIX `grep -r`/`find`. |
+| Interpolating prompt content into a shell command | Classic shell-injection path; arbitrary prompt text can execute. | Pass via stdin or `argv` with `--` separators. Never compose a command string from untrusted input. |
+| Writing to the vault on every prompt | RAG hot path writes would pollute the vault and create a feedback loop (next prompt reads what the last prompt wrote). | Only `SessionEnd` writes. `UserPromptSubmit` is read-only against the vault. |
+| Indexing `claude-memory/projects/**` in RAG | The symlinked raw transcripts feed back into retrieval; next session's RAG picks up the last session's injected `<vault-context>` and re-injects it. | Hard-exclude `claude-memory/projects/**`, `.obsidian/**`, and `.trash/**` in the RAG glob. |
+| Non-idempotent setup | Re-running `/obsidian-memory:setup` multiplies Index.md entries, duplicates MCP registrations, or rewrites working symlinks. | Every action in setup checks "does this already exist in the desired state?" before writing. Safe re-run is a success metric. |
+| Reading the user's real `~/.claude` or real vault in tests | Tests can corrupt the operator's actual Claude Code state. | Always scope tests to `$BATS_TEST_TMPDIR`. Never read `$HOME` directly. |
+| Not pinning the slug allowlist | Untrusted project names can contain path separators or `..` and escape the sessions directory. | Sanitize to `[a-z0-9-]`, collapse runs, cap length. Enforce in a single helper used by every writer. |
+
+---
+
+## References
+
+- `steering/product.md` for product direction
+- `steering/tech.md` for technical standards
+- `README.md` for user-facing overview
+- CHANGELOG.md for release history

--- a/steering/tech.md
+++ b/steering/tech.md
@@ -1,0 +1,359 @@
+# obsidian-memory Technical Steering
+
+This document defines the technology stack, constraints, and integration standards.
+All technical decisions should align with these guidelines.
+
+---
+
+## Architecture Overview
+
+```
+Claude Code session
+        │
+        ├── UserPromptSubmit ──▶ hooks/vault-rag.sh ──▶ keyword-grep over <vault>/**/*.md
+        │                                                (ripgrep; fallback: grep -r / find)
+        │                                                ──▶ emits <vault-context>…</vault-context>
+        │                                                    prepended to the prompt
+        │
+        └── SessionEnd ────────▶ hooks/vault-distill.sh ─▶ reads ~/.claude/projects/**/*.jsonl (newest)
+                                                          ──▶ spawns  CLAUDECODE="" claude -p
+                                                              (nested, non-interactive)
+                                                          ──▶ writes <vault>/claude-memory/sessions/
+                                                                      <project-slug>/YYYY-MM-DD-HHMMSS.md
+                                                          ──▶ appends link to <vault>/claude-memory/Index.md
+
+Configuration: ~/.claude/obsidian-memory/config.json (written by /obsidian-memory:setup)
+
+Storage layout inside the vault:
+  <vault>/claude-memory/
+      Index.md                 ← human-readable index (append-only link list)
+      sessions/<slug>/*.md     ← distilled session notes (one per session)
+      projects → ~/.claude/projects   (symlink; raw JSONL transcripts browsable in Obsidian)
+```
+
+No server component. No network calls on the hot path. The only subprocess spawned by a hook is `claude -p`, which the user has already authenticated.
+
+---
+
+## Technology Stack
+
+| Layer | Technology | Version |
+|-------|------------|---------|
+| Hook scripts | Bash (POSIX-leaning) | `#!/usr/bin/env bash`; must run under macOS default bash (3.2) and Linux bash 4+ |
+| Plugin manifest | Claude Code plugin schema | `plugin.json`, `hooks.json`, SKILL.md |
+| Text search (fast path) | ripgrep (`rg`) | any recent version |
+| Text search (fallback) | POSIX `grep -r` + `find` | base utilities; no GNU extensions required |
+| JSON handling | `jq` | ≥ 1.6 |
+| Distillation subprocess | Claude CLI (`claude`) | latest stable; invoked as `claude -p` with `CLAUDECODE=""` in the env |
+| Optional MCP integration | [obsidian-claude-code-mcp](https://github.com/iansinnott/obsidian-claude-code-mcp) | registered at user scope by `/obsidian-memory:setup` on opt-in |
+| Distribution | [nmg-plugins marketplace](https://github.com/Nunley-Media-Group/nmg-plugins) | user-scope install via `claude plugin install obsidian-memory` |
+
+### External Services
+
+None. obsidian-memory is local-first. The only external binary invoked is the already-authenticated `claude` CLI.
+
+---
+
+## Versioning
+
+The `plugins/obsidian-memory/.claude-plugin/plugin.json` `version` field is the **single source of truth** for the plugin's current version. A root-level `VERSION` file is not used; the plugin manifest is authoritative so the Claude Code marketplace reads the same value users install against.
+
+| File | Path | Notes |
+|------|------|-------|
+| plugins/obsidian-memory/.claude-plugin/plugin.json | `version` | Plugin manifest; authoritative. Read by Claude Code at install. |
+| .claude-plugin/marketplace.json | `plugins[0].version` | Local marketplace listing. Kept in sync with the plugin manifest. When this plugin is pulled into the upstream `nmg-plugins` marketplace, the upstream listing is the one users see. |
+| CHANGELOG.md | `line:N` for `## [X.Y.Z]` heading | Conventional Changelog; the heading line changes per release. |
+
+### Path Syntax
+
+- **JSON files**: dot-notation (e.g., `version`, `plugins[0].version`).
+- **Plain text files**: `line:N` where `N` is the line number of the version token.
+
+### Version Bump Classification
+
+The `/open-pr` skill and the `sdlc-runner.mjs` deterministic bump postcondition both read this table to classify version bumps. Modify this table to change the classification rules — no skill or script changes are needed.
+
+| Label | Bump Type | Description |
+|-------|-----------|-------------|
+| `bug` | patch | Bug fix — backwards-compatible |
+| `enhancement` | minor | New feature — backwards-compatible |
+| `chore` | patch | Internal change with no user-visible behavior (docs, test-only, refactor without behavior change) |
+
+**Default**: If an issue's labels do not match any row, the bump type is **minor**.
+
+**Major bumps are manual-only.** A developer must opt in explicitly via `/open-pr #N --major`. In unattended mode, `--major` escalates and exits without bumping.
+
+**Breaking changes use minor bumps while the plugin is pre-1.0.** Communicate the breaking nature via a `**BREAKING CHANGE:**` bold prefix on the affected CHANGELOG bullet and a `### Migration Notes` sub-section:
+
+```markdown
+## [0.3.0] - 2026-04-19
+
+### Changed (BREAKING)
+
+- **BREAKING CHANGE:** Renamed config key `rag.enabled` to `rag.enable`. Existing configs must be migrated.
+
+### Migration Notes
+
+In `~/.claude/obsidian-memory/config.json`, rename `rag.enabled` → `rag.enable` and `distill.enabled` → `distill.enable`. Running `/obsidian-memory:setup` does NOT perform the rename automatically.
+```
+
+---
+
+## Technical Constraints
+
+### Performance
+
+| Metric | Target | Rationale |
+|--------|--------|-----------|
+| `vault-rag.sh` wall time on a 1k-note vault | < 300 ms p95 | UserPromptSubmit is on every prompt. Anything slower is user-visible latency. |
+| `vault-distill.sh` wall time | Bounded only by `claude -p` | SessionEnd, not hot path; user has already left the session. Still, no polling loops. |
+| RAG payload size | `<vault-context>` block ≤ 8 KB by default | Large payloads bloat the context window and dilute the user's actual prompt. |
+
+### Security
+
+| Requirement | Implementation |
+|-------------|----------------|
+| Authentication | None at the plugin level. `claude -p` inherits the user's existing CLI auth. |
+| Authorization | Hooks only read from `<vault>` and `~/.claude/projects/`, and only write to `<vault>/claude-memory/`. Paths are read from config; the plugin never accepts paths from prompt content. |
+| Secrets management | No secrets stored by the plugin. Config contains only a vault path and enable flags. |
+| Input validation | Prompt text is never interpolated into shell commands. The RAG hook passes the prompt to `rg`/`grep` via stdin or `--` separated argv, never via command-string concatenation. |
+| Filesystem safety | All writes use absolute paths derived from `config.json`. Slugs for session filenames are `[a-z0-9-]`, collapsed and length-capped, so untrusted project names cannot escape the sessions directory. |
+
+---
+
+## Coding Standards
+
+### Bash
+
+```bash
+# GOOD — fail loudly inside the script, but exit 0 at the hook boundary
+set -u
+trap 'log_err "vault-rag.sh failed at line $LINENO"; exit 0' ERR
+
+VAULT="$(jq -r '.vault' "$CONFIG")"
+if [ -z "$VAULT" ] || [ ! -d "$VAULT" ]; then
+  exit 0   # silent no-op — hook must never block the user
+fi
+
+# GOOD — rg preferred, POSIX fallback always available
+if command -v rg >/dev/null 2>&1; then
+  rg --files-with-matches --glob '*.md' -- "$QUERY" "$VAULT"
+else
+  find "$VAULT" -type f -name '*.md' -print0 | xargs -0 grep -l -- "$QUERY"
+fi
+
+# BAD — `set -e` at a hook entry point can exit non-zero and confuse the caller
+set -e
+
+# BAD — interpolating user content into a shell command
+eval "rg \"$QUERY\" \"$VAULT\""
+
+# BAD — assuming rg is on PATH inside a hook subshell (editor-embedded rg is not)
+rg "$QUERY" "$VAULT"
+```
+
+- Shebang: `#!/usr/bin/env bash`. No `#!/bin/bash`.
+- Every top-level script has a `trap '... exit 0' ERR` so any unexpected failure still satisfies the "never block the user" principle.
+- Use `$(…)`, never backticks. Quote every variable expansion that could contain spaces (`"$VAULT"`, not `$VAULT`).
+- Prefer `[ … ]` over `[[ … ]]` when POSIX compatibility matters; `[[ … ]]` is fine inside hooks since the shebang forces bash.
+- Indent with 2 spaces. No tabs.
+- Function naming: `lower_snake_case`. Constants: `UPPER_SNAKE_CASE`.
+
+### JSON (plugin manifests, config)
+
+```json
+{
+  "name": "obsidian-memory",
+  "version": "0.1.0"
+}
+```
+
+- 2-space indentation. Trailing newline. No trailing commas.
+- Field order in `plugin.json`: `name`, `version`, `description`, `author`, `repository`, `keywords`.
+
+### Markdown (SKILL.md, README, steering, specs)
+
+- ATX headings (`#`, `##`), no setext.
+- Fenced code blocks with a language tag.
+- Line length: no hard wrap; one sentence per line in long-form prose is acceptable.
+
+---
+
+## API / Interface Standards
+
+obsidian-memory has no HTTP API. "Interfaces" means:
+
+### Hook contracts
+
+Every hook script is invoked by Claude Code per the `hooks/hooks.json` schema. The script:
+
+1. Reads its payload from stdin as JSON (for hooks that provide one) or from documented env vars.
+2. Writes its response, if any, to stdout per the Claude Code hook protocol.
+3. Exits 0 on every terminating path — success, handled error, unrecognized state.
+4. Logs unexpected failures to stderr (which Claude Code surfaces in the operator-visible hook log), never to stdout.
+
+### Skill contracts
+
+Every skill is a `SKILL.md` under `plugins/obsidian-memory/skills/<name>/SKILL.md`. Each has:
+
+1. A frontmatter block declaring `name`, `description`, `version`.
+2. A "When to Use" section.
+3. An unambiguous invocation example (`/obsidian-memory:<name> <args>`).
+4. Idempotency notes where relevant (e.g., `/obsidian-memory:setup` is safe to re-run).
+
+---
+
+## Database Standards
+
+Not applicable. obsidian-memory has no database. All state is one of:
+
+- `~/.claude/obsidian-memory/config.json` — flat JSON config.
+- `<vault>/claude-memory/sessions/**/*.md` — append-only Markdown files.
+- `<vault>/claude-memory/Index.md` — append-only index; links only, no semantic content.
+- `<vault>/claude-memory/projects` — symlink to `~/.claude/projects` (the raw JSONL transcripts).
+
+---
+
+## Testing Standards
+
+### BDD Testing (Required for nmg-sdlc)
+
+**Every acceptance criterion MUST have a Gherkin scenario.**
+
+| Layer | Framework | Location |
+|-------|-----------|----------|
+| BDD scenarios | cucumber-shell (shell-native Gherkin runner) | `specs/<feature-slug>/feature.gherkin` authored by `/write-spec`; step definitions under `tests/features/steps/*.sh` |
+| Unit | [bats-core](https://github.com/bats-core/bats-core) | `tests/unit/*.bats` |
+| Integration (end-to-end hook harness) | bats-core with a scratch `$HOME` and scratch vault | `tests/integration/*.bats` |
+
+### Gherkin Feature Files
+
+```gherkin
+# specs/feature-<slug>/feature.gherkin
+Feature: Vault RAG injects matching notes
+  As a Claude Code + Obsidian user
+  I want relevant prior notes surfaced on every prompt
+  So that Claude answers with continuity across sessions
+
+  Scenario: A vault note contains a keyword from the prompt
+    Given an Obsidian vault at "$VAULT" containing "my-note.md" with the text "jq is used for config parsing"
+    And   obsidian-memory is installed and setup against "$VAULT"
+    When  the user submits a prompt containing "jq"
+    Then  the UserPromptSubmit hook output contains a "<vault-context>" block
+    And   the block contains "my-note.md"
+
+  Scenario: Vault is empty
+    Given an empty Obsidian vault at "$VAULT"
+    And   obsidian-memory is installed and setup against "$VAULT"
+    When  the user submits any prompt
+    Then  the UserPromptSubmit hook exits 0
+    And   the hook emits no "<vault-context>" block
+```
+
+### Step Definitions
+
+```bash
+# tests/features/steps/vault-rag.sh
+# Conventions:
+#   - One step definition per function; function names mirror the Given/When/Then phrasing.
+#   - All filesystem state lives under $BATS_TEST_TMPDIR (scratch vault, scratch HOME).
+#   - Never touch the operator's real ~/.claude or real Obsidian vault.
+
+given_a_vault_at_containing_with_the_text() {
+  local vault="$1" file="$2" text="$3"
+  mkdir -p "$vault"
+  printf '%s\n' "$text" > "$vault/$file"
+}
+
+when_the_user_submits_a_prompt_containing() {
+  local query="$1"
+  HOOK_INPUT=$(jq -n --arg q "$query" '{prompt: $q}')
+  HOOK_OUTPUT=$(printf '%s' "$HOOK_INPUT" | "$PLUGIN_ROOT/hooks/vault-rag.sh")
+}
+
+then_the_hook_output_contains_a_vault_context_block() {
+  echo "$HOOK_OUTPUT" | grep -q '<vault-context>'
+}
+```
+
+### Unit Tests
+
+| Type | Framework | Location | Run Command |
+|------|-----------|----------|-------------|
+| Unit | bats-core | `tests/unit/` | `bats tests/unit` |
+| Integration | bats-core (with scratch `$HOME` + scratch vault) | `tests/integration/` | `bats tests/integration` |
+| BDD | cucumber-shell | `specs/**/feature.gherkin` + `tests/features/steps/` | `tests/run-bdd.sh` |
+| Static | shellcheck | every `*.sh` | `shellcheck plugins/**/*.sh scripts/*.sh tests/**/*.sh` |
+
+### Test Pyramid
+
+```
+        /\
+       /  \  BDD Integration (Gherkin, cucumber-shell)
+      /----\  - Acceptance criteria for every spec
+     /      \ - Full hook-invocation round-trips against a scratch vault
+    /--------\
+   /          \  bats integration tests
+  /            \ - One scratch $HOME, one scratch vault, real scripts
+ /--------------\
+/                \  bats unit tests + shellcheck
+ \________________/ - Pure-function shell helpers, slug sanitization, jq filters
+```
+
+---
+
+## Verification Gates
+
+The `/verify-code` skill enforces these as hard gates. Each gate specifies when it applies, what command to run, and how to determine success.
+
+| Gate | Condition | Action | Pass Criteria |
+|------|-----------|--------|---------------|
+| Shellcheck | Always | `shellcheck plugins/**/*.sh tests/**/*.sh scripts/*.sh 2>/dev/null \|\| shellcheck $(find plugins tests scripts -name '*.sh')` | Exit code 0 |
+| Unit Tests | `tests/unit/` directory exists | `bats tests/unit` | Exit code 0 |
+| Integration Tests | `tests/integration/` directory exists | `bats tests/integration` | Exit code 0 |
+| BDD Tests | `specs/*/feature.gherkin` files exist | `tests/run-bdd.sh` | Exit code 0 |
+| JSON validity | Always | `jq empty plugins/obsidian-memory/.claude-plugin/plugin.json plugins/obsidian-memory/hooks/hooks.json .claude-plugin/marketplace.json` | Exit code 0 |
+
+### Condition Evaluation Rules
+
+- `Always` — gate always applies
+- `{path} directory exists` — gate applies only when the directory is present (`test -d {path}`)
+- `{glob} files exist in {path}` — gate applies only when matching files are found in the given path
+
+### Pass Criteria Evaluation Rules
+
+- `Exit code 0` — the Action command must exit with code 0
+- `{file} file generated` — the named file must exist after the Action command completes
+- `output contains "{text}"` — stdout or stderr must contain the specified text
+- Compound criteria use `AND` — all sub-criteria must be satisfied
+- The `/verify-code` skill evaluates these textual criteria against actual results — no stack-specific logic is needed
+
+---
+
+## Environment Variables
+
+### Required
+
+None at install time. The plugin reads everything it needs from `~/.claude/obsidian-memory/config.json` once `/obsidian-memory:setup` has run.
+
+### Used by the distillation hook
+
+| Variable | Description |
+|----------|-------------|
+| `CLAUDECODE` | Cleared (`CLAUDECODE=""`) before spawning the nested `claude -p` so the inner CLI does not inherit the outer session's Claude Code sentinel. Required; without it, the nested invocation can loop or misbehave. |
+
+### Used by tests
+
+| Variable | Description |
+|----------|-------------|
+| `BATS_TEST_TMPDIR` | Provided by bats; test scratch directory. All test-written files live here. |
+| `PLUGIN_ROOT` | Set by the bats test helper to the absolute path of `plugins/obsidian-memory`. |
+
+---
+
+## References
+
+- CLAUDE.md for project overview (if present)
+- `steering/product.md` for product direction
+- `steering/structure.md` for code organization
+- Upstream marketplace: https://github.com/Nunley-Media-Group/nmg-plugins


### PR DESCRIPTION
## Summary

- Bootstraps `steering/product.md`, `steering/tech.md`, and `steering/structure.md` from the `/onboard-project` greenfield interview + the existing README.
- Adds `.gitignore` entries for `sdlc-config.json` and `.claude/sdlc-state.json` so the SDLC runner config stays local.
- Corresponds to the 7 starter issues seeded in milestone `v1 (MVP)`: #1 — #7.

## Interview summary

| Field | Value |
|-------|-------|
| Vision | obsidian-memory plugin (distributed via the external `nmg-plugins` marketplace — not itself a marketplace) |
| Personas | Claude Code + Obsidian power users; AI-tooling tinkerers |
| Success | RAG relevance ≥60% / zero hallucinated distillations / zero blocking hooks |
| Language | Bash / POSIX shell |
| Framework | Claude Code plugin (hooks + skills) |
| Tests | bats-core + cucumber-shell |
| Deploy | nmg-plugins marketplace, user-scope install |

## Test plan

- [ ] Skim each steering file for anything the interview missed or got wrong.
- [ ] Confirm the Verification Gates table in `steering/tech.md` matches the harness planned in issue #1.
- [ ] Confirm `.gitignore` is complete — nothing secret should be tracked.
- [ ] Run `/start-issue #1` (test harness) after merge to begin the MVP.