### PR TITLE
feat: add /obsidian-memory:doctor health-check skill (#2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-memory",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cross-session memory backed by an Obsidian vault. Retrieves relevant notes on every prompt and distills each session into a dated vault entry.",
   "author": {
     "name": "Rich Nunley",

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"cfe62819-c68d-4692-b7c6-7017f4dc3479","pid":2941,"acquiredAt":1776810080442}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # SDLC runner config
 sdlc-config.json
 .claude/sdlc-state.json
+
+# SDLC runner artifacts
+.claude/unattended-mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to plugins in this marketplace are documented here. Format f
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-21
+
+### Added
+
+- `/obsidian-memory:doctor` skill — on-demand health check that surfaces silent install failures without mutating any state. Reports `OK`/`FAIL` per check (config presence, vault path, `jq`/`claude`/`ripgrep` on PATH, `claude-memory/sessions/` directory, `claude-memory/projects` symlink, `rag.enabled`/`distill.enabled` flags) with one-line remediation hints. Exits 0 if all checks pass, non-zero on any failure. Supports `--json` for machine-readable output.
+
+## [0.1.0] - 2026-04-21
+
 ### Added
 
 - **obsidian-memory 0.1.0** — new plugin providing automatic, Obsidian-backed cross-session memory for Claude Code.

--- a/scripts/vault-doctor.sh
+++ b/scripts/vault-doctor.sh
@@ -47,6 +47,7 @@ _record() {
 # --- Probe helpers -----------------------------------------------------------
 
 _jq_available=1
+_claude_available=1
 _config_readable=0
 _vault_path=""
 
@@ -112,6 +113,7 @@ probe_claude() {
     _record "claude" "fail" \
       "claude not on PATH" \
       "install the Claude Code CLI; see https://docs.claude.com/claude-code"
+    _claude_available=0
   fi
 }
 
@@ -178,39 +180,22 @@ _flag_enabled() {
   printf '%s' "$val"
 }
 
-probe_rag_enabled() {
+probe_flag_enabled() {
+  local feature="$1"
   if [ "$_config_readable" -ne 1 ] || [ "$_jq_available" -ne 1 ]; then
-    _record "rag_enabled" "fail" \
-      "cannot check rag.enabled — config or jq missing" \
+    _record "${feature}_enabled" "fail" \
+      "cannot check ${feature}.enabled — config or jq missing" \
       "run /obsidian-memory:setup <vault>"
     return
   fi
   local val
-  val="$(_flag_enabled rag)"
+  val="$(_flag_enabled "$feature")"
   if [ "$val" = "true" ]; then
-    _record "rag_enabled" "ok" "true"
+    _record "${feature}_enabled" "ok" "true"
   else
-    _record "rag_enabled" "fail" \
-      "rag.enabled is false in config" \
-      "run /obsidian-memory:toggle rag on"
-  fi
-}
-
-probe_distill_enabled() {
-  if [ "$_config_readable" -ne 1 ] || [ "$_jq_available" -ne 1 ]; then
-    _record "distill_enabled" "fail" \
-      "cannot check distill.enabled — config or jq missing" \
-      "run /obsidian-memory:setup <vault>"
-    return
-  fi
-  local val
-  val="$(_flag_enabled distill)"
-  if [ "$val" = "true" ]; then
-    _record "distill_enabled" "ok" "true"
-  else
-    _record "distill_enabled" "fail" \
-      "distill.enabled is false in config" \
-      "run /obsidian-memory:toggle distill on"
+    _record "${feature}_enabled" "fail" \
+      "${feature}.enabled is false in config" \
+      "run /obsidian-memory:toggle ${feature} on"
   fi
 }
 
@@ -224,21 +209,25 @@ probe_ripgrep() {
 }
 
 probe_mcp() {
-  if ! command -v claude >/dev/null 2>&1; then
+  if [ "$_claude_available" -ne 1 ]; then
     _record "mcp" "info" "claude not on PATH — mcp status unknown"
     return
   fi
 
-  local out rc
+  # Keep `|| rc=$?` so the ERR trap doesn't fire when claude itself exits non-zero.
+  local out rc=0
   if command -v timeout >/dev/null 2>&1; then
-    out="$(timeout 3 claude mcp list 2>/dev/null || true)"
-    rc=$?
+    out="$(timeout 3 claude mcp list 2>/dev/null)" || rc=$?
   else
-    out="$(claude mcp list 2>/dev/null || true)"
-    rc=$?
+    out="$(claude mcp list 2>/dev/null)" || rc=$?
   fi
 
-  if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ] && [ -z "$out" ]; then
+  if [ "$rc" -eq 124 ]; then
+    _record "mcp" "info" "mcp status unknown (claude mcp list timed out)"
+    return
+  fi
+
+  if [ "$rc" -ne 0 ] && [ -z "$out" ]; then
     _record "mcp" "info" "mcp status unknown"
     return
   fi
@@ -299,15 +288,16 @@ emit_human() {
 }
 
 emit_json() {
-  if ! command -v jq >/dev/null 2>&1; then
+  local ok=true i n="${#PROBE_KEYS[@]}"
+  for (( i = 0; i < n; i++ )); do
+    if [ "${PROBE_STATUS[$i]}" = "fail" ]; then ok=false; break; fi
+  done
+
+  if [ "$_jq_available" -ne 1 ]; then
     # Fallback: hand-assembled JSON. Strings have no special chars in practice
     # (paths + ASCII hints), but we still quote conservatively.
-    local i ok=true n="${#PROBE_KEYS[@]}" first=1
-    printf '{"ok":'
-    for (( i = 0; i < n; i++ )); do
-      if [ "${PROBE_STATUS[$i]}" = "fail" ]; then ok=false; break; fi
-    done
-    printf '%s,"checks":{' "$ok"
+    local first=1
+    printf '{"ok":%s,"checks":{' "$ok"
     for (( i = 0; i < n; i++ )); do
       if [ "$first" -eq 0 ]; then printf ','; fi
       first=0
@@ -328,12 +318,6 @@ emit_json() {
     return
   fi
 
-  local ok=true i n="${#PROBE_KEYS[@]}"
-  for (( i = 0; i < n; i++ )); do
-    if [ "${PROBE_STATUS[$i]}" = "fail" ]; then ok=false; break; fi
-  done
-
-  # Build the checks object via jq -n with --arg pairs for each probe.
   local args=()
   for (( i = 0; i < n; i++ )); do
     args+=( --arg "k$i" "${PROBE_KEYS[$i]}" )
@@ -344,18 +328,15 @@ emit_json() {
 
   # shellcheck disable=SC2016  # $ok is a jq variable, not a shell expansion
   local filter='{ok: $ok, checks: {}}'
-  local idx
   for (( i = 0; i < n; i++ )); do
-    idx="$i"
-    # Assemble check entry matching the declared schema.
     filter="$filter
-      | .checks[\$k${idx}] = (
-          if \$s${idx} == \"fail\" then
-            {status: \$s${idx}, reason: \$d${idx}, hint: \$h${idx}}
-          elif \$s${idx} == \"info\" then
-            {status: \$s${idx}, note: \$d${idx}}
+      | .checks[\$k${i}] = (
+          if \$s${i} == \"fail\" then
+            {status: \$s${i}, reason: \$d${i}, hint: \$h${i}}
+          elif \$s${i} == \"info\" then
+            {status: \$s${i}, note: \$d${i}}
           else
-            {status: \$s${idx}}
+            {status: \$s${i}}
           end
         )"
   done
@@ -403,8 +384,8 @@ main() {
   probe_claude
   probe_sessions_dir
   probe_projects_symlink
-  probe_rag_enabled
-  probe_distill_enabled
+  probe_flag_enabled rag
+  probe_flag_enabled distill
   probe_ripgrep
   probe_mcp
 

--- a/scripts/vault-doctor.sh
+++ b/scripts/vault-doctor.sh
@@ -1,0 +1,426 @@
+#!/usr/bin/env bash
+# vault-doctor.sh — read-only install-state reporter for obsidian-memory.
+#
+# Runs every probe without short-circuiting so the user sees the full picture
+# from a single invocation. Never mutates the filesystem. Exits 0 if every
+# probe is OK/INFO; exits 1 if any probe is FAIL; exits 2 on bad usage.
+
+set -u
+
+# shellcheck disable=SC2329  # invoked indirectly by the ERR trap
+log_err() { printf '[%s] %s\n' "$(basename "$0")" "$*" >&2; }
+trap 'log_err "failed at line $LINENO"; exit 1' ERR
+
+CONFIG="${HOME}/.claude/obsidian-memory/config.json"
+
+# --- ANSI color (TTY only) ---------------------------------------------------
+
+if [ -t 1 ]; then
+  C_RESET=$'\033[0m'
+  C_GREEN=$'\033[32m'
+  C_RED=$'\033[31m'
+  C_YELLOW=$'\033[33m'
+  C_BOLD=$'\033[1m'
+else
+  C_RESET=""
+  C_GREEN=""
+  C_RED=""
+  C_YELLOW=""
+  C_BOLD=""
+fi
+
+# --- Result accumulators (parallel arrays keyed by index) -------------------
+
+PROBE_KEYS=()
+PROBE_STATUS=()   # ok | fail | info
+PROBE_DETAIL=()   # human-readable detail (path, reason, note)
+PROBE_HINT=()     # remediation hint (fail only; empty otherwise)
+
+_record() {
+  # $1 = key, $2 = status, $3 = detail, $4 = hint (optional)
+  PROBE_KEYS+=("$1")
+  PROBE_STATUS+=("$2")
+  PROBE_DETAIL+=("$3")
+  PROBE_HINT+=("${4:-}")
+}
+
+# --- Probe helpers -----------------------------------------------------------
+
+_jq_available=1
+_config_readable=0
+_vault_path=""
+
+probe_config() {
+  if [ -r "$CONFIG" ]; then
+    _record "config" "ok" "$CONFIG"
+    _config_readable=1
+  else
+    _record "config" "fail" \
+      "config file $CONFIG is missing" \
+      "run /obsidian-memory:setup <vault>"
+  fi
+}
+
+probe_jq() {
+  if command -v jq >/dev/null 2>&1; then
+    _record "jq" "ok" "$(command -v jq)"
+  else
+    _record "jq" "fail" "jq not on PATH" "brew install jq"
+    _jq_available=0
+  fi
+}
+
+probe_vault_path() {
+  if [ "$_config_readable" -ne 1 ]; then
+    _record "vault_path" "fail" \
+      "cannot check vaultPath — config missing" \
+      "run /obsidian-memory:setup <vault>"
+    return
+  fi
+  if [ "$_jq_available" -ne 1 ]; then
+    _record "vault_path" "fail" \
+      "cannot check vaultPath — jq missing" \
+      "brew install jq"
+    return
+  fi
+
+  local raw
+  raw="$(jq -r '.vaultPath // ""' "$CONFIG" 2>/dev/null || printf '')"
+  if [ -z "$raw" ] || [ "$raw" = "null" ]; then
+    _record "vault_path" "fail" \
+      "vaultPath missing from config" \
+      "run /obsidian-memory:setup <vault>"
+    return
+  fi
+
+  _vault_path="$raw"
+
+  if [ ! -d "$raw" ]; then
+    _record "vault_path" "fail" \
+      "vault path $raw does not exist" \
+      "run /obsidian-memory:setup <vault>"
+    return
+  fi
+
+  _record "vault_path" "ok" "$raw"
+}
+
+probe_claude() {
+  if command -v claude >/dev/null 2>&1; then
+    _record "claude" "ok" "$(command -v claude)"
+  else
+    _record "claude" "fail" \
+      "claude not on PATH" \
+      "install the Claude Code CLI; see https://docs.claude.com/claude-code"
+  fi
+}
+
+probe_sessions_dir() {
+  if [ -z "$_vault_path" ]; then
+    _record "sessions_dir" "fail" \
+      "cannot check sessions directory — vault path unresolved" \
+      "run /obsidian-memory:setup <vault>"
+    return
+  fi
+  local sessions="$_vault_path/claude-memory/sessions"
+  if [ -d "$sessions" ]; then
+    _record "sessions_dir" "ok" "$sessions"
+  else
+    _record "sessions_dir" "fail" \
+      "sessions directory $sessions does not exist" \
+      "run /obsidian-memory:setup <vault>"
+  fi
+}
+
+probe_projects_symlink() {
+  if [ -z "$_vault_path" ]; then
+    _record "projects_symlink" "fail" \
+      "cannot check projects symlink — vault path unresolved" \
+      "run /obsidian-memory:setup <vault>"
+    return
+  fi
+  local link="$_vault_path/claude-memory/projects"
+  local expected="$HOME/.claude/projects"
+
+  if [ ! -L "$link" ]; then
+    _record "projects_symlink" "fail" \
+      "projects symlink $link is missing" \
+      "run /obsidian-memory:setup <vault>"
+    return
+  fi
+
+  local target
+  target="$(readlink "$link" 2>/dev/null || printf '')"
+  if [ "$target" != "$expected" ]; then
+    _record "projects_symlink" "fail" \
+      "projects symlink $link points at $target (expected $expected)" \
+      "run /obsidian-memory:setup <vault>"
+    return
+  fi
+
+  if [ ! -e "$link" ]; then
+    _record "projects_symlink" "fail" \
+      "projects symlink $link is broken (target $target does not exist)" \
+      "run /obsidian-memory:setup <vault>"
+    return
+  fi
+
+  _record "projects_symlink" "ok" "$link -> $target"
+}
+
+_flag_enabled() {
+  # Echo "true" or "false". Unset flags read as true (matches _common.sh).
+  # Using `!= false` rather than `// true` because jq's `//` alternative
+  # operator treats `false` as "absent" and would wrongly fall through.
+  local key="$1"
+  local val
+  val="$(jq -r "(.${key}.enabled != false) | tostring" "$CONFIG" 2>/dev/null || printf 'true')"
+  printf '%s' "$val"
+}
+
+probe_rag_enabled() {
+  if [ "$_config_readable" -ne 1 ] || [ "$_jq_available" -ne 1 ]; then
+    _record "rag_enabled" "fail" \
+      "cannot check rag.enabled — config or jq missing" \
+      "run /obsidian-memory:setup <vault>"
+    return
+  fi
+  local val
+  val="$(_flag_enabled rag)"
+  if [ "$val" = "true" ]; then
+    _record "rag_enabled" "ok" "true"
+  else
+    _record "rag_enabled" "fail" \
+      "rag.enabled is false in config" \
+      "run /obsidian-memory:toggle rag on"
+  fi
+}
+
+probe_distill_enabled() {
+  if [ "$_config_readable" -ne 1 ] || [ "$_jq_available" -ne 1 ]; then
+    _record "distill_enabled" "fail" \
+      "cannot check distill.enabled — config or jq missing" \
+      "run /obsidian-memory:setup <vault>"
+    return
+  fi
+  local val
+  val="$(_flag_enabled distill)"
+  if [ "$val" = "true" ]; then
+    _record "distill_enabled" "ok" "true"
+  else
+    _record "distill_enabled" "fail" \
+      "distill.enabled is false in config" \
+      "run /obsidian-memory:toggle distill on"
+  fi
+}
+
+probe_ripgrep() {
+  if command -v rg >/dev/null 2>&1; then
+    _record "ripgrep" "info" "$(command -v rg)"
+  else
+    _record "ripgrep" "info" \
+      "ripgrep not on PATH — vault-rag.sh will use POSIX fallback"
+  fi
+}
+
+probe_mcp() {
+  if ! command -v claude >/dev/null 2>&1; then
+    _record "mcp" "info" "claude not on PATH — mcp status unknown"
+    return
+  fi
+
+  local out rc
+  if command -v timeout >/dev/null 2>&1; then
+    out="$(timeout 3 claude mcp list 2>/dev/null || true)"
+    rc=$?
+  else
+    out="$(claude mcp list 2>/dev/null || true)"
+    rc=$?
+  fi
+
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ] && [ -z "$out" ]; then
+    _record "mcp" "info" "mcp status unknown"
+    return
+  fi
+
+  if printf '%s' "$out" | grep -qi 'obsidian'; then
+    _record "mcp" "info" "obsidian MCP server registered"
+  else
+    _record "mcp" "info" "obsidian MCP server not registered"
+  fi
+}
+
+# --- Output formatters -------------------------------------------------------
+
+_status_label() {
+  case "$1" in
+    ok)   printf '%sOK  %s' "$C_GREEN" "$C_RESET" ;;
+    fail) printf '%sFAIL%s' "$C_RED" "$C_RESET" ;;
+    info) printf '%sINFO%s' "$C_YELLOW" "$C_RESET" ;;
+    *)    printf '%s' "$1" ;;
+  esac
+}
+
+emit_human() {
+  printf '%sobsidian-memory doctor%s\n' "$C_BOLD" "$C_RESET"
+  printf '%s\n' "──────────────────────"
+
+  local fails=0 i status detail hint label line
+  local n="${#PROBE_KEYS[@]}"
+  for (( i = 0; i < n; i++ )); do
+    status="${PROBE_STATUS[$i]}"
+    detail="${PROBE_DETAIL[$i]}"
+    hint="${PROBE_HINT[$i]}"
+    label="$(_status_label "$status")"
+    case "$status" in
+      ok)
+        printf '%s  %-18s %s\n' "$label" "${PROBE_KEYS[$i]}" "$detail"
+        ;;
+      fail)
+        line="${PROBE_KEYS[$i]}: $detail"
+        if [ -n "$hint" ]; then
+          line="$line — $hint"
+        fi
+        printf '%s  %s\n' "$label" "$line"
+        fails=$((fails + 1))
+        ;;
+      info)
+        printf '%s  %-18s %s\n' "$label" "${PROBE_KEYS[$i]}" "$detail"
+        ;;
+    esac
+  done
+
+  printf '\n'
+  if [ "$fails" -eq 0 ]; then
+    printf '%sAll checks passed.%s\n' "$C_BOLD" "$C_RESET"
+  else
+    printf '%s%d check(s) failed.%s\n' "$C_BOLD" "$fails" "$C_RESET"
+  fi
+}
+
+emit_json() {
+  if ! command -v jq >/dev/null 2>&1; then
+    # Fallback: hand-assembled JSON. Strings have no special chars in practice
+    # (paths + ASCII hints), but we still quote conservatively.
+    local i ok=true n="${#PROBE_KEYS[@]}" first=1
+    printf '{"ok":'
+    for (( i = 0; i < n; i++ )); do
+      if [ "${PROBE_STATUS[$i]}" = "fail" ]; then ok=false; break; fi
+    done
+    printf '%s,"checks":{' "$ok"
+    for (( i = 0; i < n; i++ )); do
+      if [ "$first" -eq 0 ]; then printf ','; fi
+      first=0
+      printf '"%s":{"status":"%s"' "${PROBE_KEYS[$i]}" "${PROBE_STATUS[$i]}"
+      case "${PROBE_STATUS[$i]}" in
+        fail)
+          printf ',"reason":"%s","hint":"%s"' \
+            "$(_json_escape "${PROBE_DETAIL[$i]}")" \
+            "$(_json_escape "${PROBE_HINT[$i]}")"
+          ;;
+        info)
+          printf ',"note":"%s"' "$(_json_escape "${PROBE_DETAIL[$i]}")"
+          ;;
+      esac
+      printf '}'
+    done
+    printf '}}\n'
+    return
+  fi
+
+  local ok=true i n="${#PROBE_KEYS[@]}"
+  for (( i = 0; i < n; i++ )); do
+    if [ "${PROBE_STATUS[$i]}" = "fail" ]; then ok=false; break; fi
+  done
+
+  # Build the checks object via jq -n with --arg pairs for each probe.
+  local args=()
+  for (( i = 0; i < n; i++ )); do
+    args+=( --arg "k$i" "${PROBE_KEYS[$i]}" )
+    args+=( --arg "s$i" "${PROBE_STATUS[$i]}" )
+    args+=( --arg "d$i" "${PROBE_DETAIL[$i]}" )
+    args+=( --arg "h$i" "${PROBE_HINT[$i]}" )
+  done
+
+  # shellcheck disable=SC2016  # $ok is a jq variable, not a shell expansion
+  local filter='{ok: $ok, checks: {}}'
+  local idx
+  for (( i = 0; i < n; i++ )); do
+    idx="$i"
+    # Assemble check entry matching the declared schema.
+    filter="$filter
+      | .checks[\$k${idx}] = (
+          if \$s${idx} == \"fail\" then
+            {status: \$s${idx}, reason: \$d${idx}, hint: \$h${idx}}
+          elif \$s${idx} == \"info\" then
+            {status: \$s${idx}, note: \$d${idx}}
+          else
+            {status: \$s${idx}}
+          end
+        )"
+  done
+
+  jq -n --argjson ok "$ok" "${args[@]}" "$filter"
+}
+
+_json_escape() {
+  # Minimal JSON string escaping for the fallback encoder. Not bulletproof,
+  # but enough for ASCII paths and hints we actually emit.
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g' -e 's/$/\\n/g' | tr -d '\n' | sed 's/\\n$//'
+}
+
+# --- CLI ---------------------------------------------------------------------
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: vault-doctor.sh [--json]
+
+  --json   Emit a machine-readable JSON report.
+
+Prints a read-only health check of the obsidian-memory install. Exits 0 if
+every probe is OK or INFO; exits 1 if any probe is FAIL.
+USAGE
+}
+
+main() {
+  local json_mode=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --json) json_mode=1 ;;
+      -h|--help) usage; exit 0 ;;
+      *) usage; exit 2 ;;
+    esac
+    shift
+  done
+
+  if [ "$json_mode" -eq 1 ]; then
+    C_RESET=""; C_GREEN=""; C_RED=""; C_YELLOW=""; C_BOLD=""
+  fi
+
+  probe_config
+  probe_jq
+  probe_vault_path
+  probe_claude
+  probe_sessions_dir
+  probe_projects_symlink
+  probe_rag_enabled
+  probe_distill_enabled
+  probe_ripgrep
+  probe_mcp
+
+  if [ "$json_mode" -eq 1 ]; then
+    emit_json
+  else
+    emit_human
+  fi
+
+  local i n="${#PROBE_KEYS[@]}"
+  for (( i = 0; i < n; i++ )); do
+    if [ "${PROBE_STATUS[$i]}" = "fail" ]; then
+      exit 1
+    fi
+  done
+  exit 0
+}
+
+main "$@"

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: doctor
+description: Read-only health check for the obsidian-memory install — reports config, vault, dependency, and flag status with one-line remediation hints. Use when the user says "check obsidian-memory install", "is my obsidian-memory setup working", "diagnose obsidian-memory", "health check obsidian-memory", or invokes /obsidian-memory:doctor.
+allowed-tools: Bash, Read
+model: sonnet
+effort: low
+---
+
+# obsidian-memory: doctor
+
+Run a one-command health check against the local obsidian-memory install and report whether every piece — config, vault, dependencies, and feature flags — is wired up correctly. Doctor is strictly a **reporter**: it inspects state and prints remediation hints, but it never mutates the config, the vault, or the `~/.claude/projects` symlink. Fixing is the job of `/obsidian-memory:setup`.
+
+## When to Use
+
+- Immediately after running `/obsidian-memory:setup` to confirm the install is healthy.
+- When silent hook behavior is suspected ("my sessions don't seem to be distilling").
+- Before filing a bug — the output pinpoints which component is broken.
+- When ripping out and reinstalling the plugin, to verify the clean state.
+
+## When NOT to Use
+
+- To fix a broken install — use `/obsidian-memory:setup` or `/obsidian-memory:toggle`.
+- To verify live RAG retrieval against an actual prompt — that is covered by the integration tests, not doctor.
+- To inspect vault contents — doctor reports presence only, never reads note bodies.
+
+## Invocation
+
+```
+/obsidian-memory:doctor         # human-readable report, ANSI-colored on TTY
+/obsidian-memory:doctor --json  # machine-readable JSON report
+```
+
+## Behavior
+
+1. Invoke `"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/obsidian-memory}/scripts/vault-doctor.sh"` with any arguments the user passed (e.g., `--json`), using `"$@"` so flags pass through verbatim.
+2. Relay the script's stdout and exit code directly — do not re-interpret the results, do not re-run the script, and do not attempt to fix anything.
+3. If the exit code is non-zero, call out the specific failing line(s) in a short summary ("RAG is disabled — run /obsidian-memory:toggle rag on") so the user doesn't have to re-read the full report.
+
+The script itself is read-only: no `>`, `>>`, `mv`, `rm`, `ln`, or `mkdir` anywhere in its body. This is an enforced invariant — doctor would rather report `FAIL` than mutate state.
+
+## Checks Performed
+
+| Check | Status vocabulary | Remediation hint (on FAIL) |
+|-------|-------------------|----------------------------|
+| `config` | ok / fail | `run /obsidian-memory:setup <vault>` |
+| `jq` | ok / fail | `brew install jq` |
+| `vault_path` | ok / fail | `run /obsidian-memory:setup <vault>` |
+| `claude` | ok / fail | `install the Claude Code CLI; see https://docs.claude.com/claude-code` |
+| `sessions_dir` | ok / fail | `run /obsidian-memory:setup <vault>` |
+| `projects_symlink` | ok / fail | `run /obsidian-memory:setup <vault>` |
+| `rag_enabled` | ok / fail | `run /obsidian-memory:toggle rag on` |
+| `distill_enabled` | ok / fail | `run /obsidian-memory:toggle distill on` |
+| `ripgrep` | info | (optional; vault-rag.sh falls back to POSIX `grep -r`) |
+| `mcp` | info | (optional; Obsidian MCP server registration) |
+
+## Idempotency
+
+Safe to re-run indefinitely. Doctor performs no writes.
+
+## Error handling
+
+- If `jq` is missing, jq-dependent probes degrade to `FAIL: cannot check — …` with an actionable hint rather than crashing.
+- If `claude mcp list` errors or times out (3 s cap when `timeout` is available), the MCP probe falls back to `INFO: mcp status unknown`.
+- Any unexpected runtime failure trips the script's `ERR` trap and exits 1 — the skill relays that exit code.
+
+## Related skills
+
+- `/obsidian-memory:setup` writes the config, creates the sessions directory, and manages the projects symlink. Run it (or re-run it) when doctor reports any of those as `FAIL`.
+- `/obsidian-memory:distill-session` checkpoints the newest transcript on demand. Doctor has no opinion on whether distillation itself succeeds — only on whether the prerequisites are in place.

--- a/specs/feature-doctor-health-check-skill/design.md
+++ b/specs/feature-doctor-health-check-skill/design.md
@@ -98,7 +98,7 @@ OK    vault_path     /Users/x/Vault
 OK    jq             /opt/homebrew/bin/jq (jq-1.7)
 OK    claude         /Users/x/.local/bin/claude
 OK    sessions_dir   /Users/x/Vault/claude-memory/sessions
-OK    projects_link  /Users/x/Vault/claude-memory/projects → /Users/x/.claude/projects
+OK    projects_symlink /Users/x/Vault/claude-memory/projects → /Users/x/.claude/projects
 OK    rag_enabled    true
 OK    distill_enabled true
 INFO  ripgrep        /opt/homebrew/bin/rg

--- a/specs/feature-doctor-health-check-skill/design.md
+++ b/specs/feature-doctor-health-check-skill/design.md
@@ -1,0 +1,257 @@
+# Design: Doctor Health-Check Skill
+
+**Issues**: #2
+**Date**: 2026-04-21
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## Overview
+
+The doctor skill is a read-only install-state reporter. The skill entry point is `skills/doctor/SKILL.md`, which instructs Claude to invoke a shell script (`scripts/vault-doctor.sh`) and relay its exit code and output. Putting the logic in a shell script — rather than in the SKILL's Markdown body — lets bats exercise every check deterministically without spawning the Claude CLI.
+
+The script performs an ordered list of independent probes. Each probe is a pure function that inspects a path or a `PATH`-resolved binary and returns one of three states: `OK`, `FAIL` (with reason + hint), or `INFO` (informational only, never gates the exit code). Probes never short-circuit — doctor runs every check even if an earlier one failed, so the user sees the complete picture after a single invocation.
+
+The script is the only new runtime artifact; all tests run against a scratch `$HOME` using the existing `tests/helpers/scratch.bash` harness (shipped with issue #1), so the integration tests can assert the read-only invariant via the `assert_home_untouched` helper already in place.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  User invokes /obsidian-memory:doctor [--json]             │
+└────────────────────────┬───────────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│  skills/doctor/SKILL.md                                    │
+│   - documents the command, flags, read-only guarantee      │
+│   - instructs Claude to run scripts/vault-doctor.sh        │
+│   - relays exit code + output verbatim                     │
+└────────────────────────┬───────────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│  scripts/vault-doctor.sh                                   │
+│   - parse args (--json)                                    │
+│   - run each probe (see Data Flow)                         │
+│   - format + emit report (human or JSON)                   │
+│   - exit 0 if all probes are OK or INFO; exit 1 otherwise  │
+└─────┬──────────────────────────────────────────────────────┘
+      │
+      ▼  READ ONLY (fs, env, PATH)
+┌──────────────────────┐  ┌──────────────────────┐  ┌──────────────────────┐
+│ $CONFIG JSON         │  │ $VAULT/claude-memory │  │ PATH binaries        │
+│ (jq parse)           │  │ (stat / readlink)    │  │ (command -v)         │
+└──────────────────────┘  └──────────────────────┘  └──────────────────────┘
+```
+
+### Data Flow
+
+```
+1. SKILL.md receives invocation → shells out to scripts/vault-doctor.sh with any args.
+2. vault-doctor.sh parses --json flag; decides output mode.
+3. For each probe (ordered):
+     P1 config_exists       → read $CONFIG file presence
+     P2 vault_path_present  → jq `.vaultPath` from $CONFIG
+     P3 vault_path_is_dir   → test -d on vaultPath
+     P4 jq_on_path          → command -v jq  (Note: P1/P2 degrade gracefully when jq is missing)
+     P5 claude_on_path      → command -v claude
+     P6 sessions_dir        → test -d "<vault>/claude-memory/sessions"
+     P7 projects_symlink    → test -L + readlink resolves to ~/.claude/projects
+     P8 rag_enabled         → jq `.rag.enabled != false`
+     P9 distill_enabled     → jq `.distill.enabled != false`
+    I1 ripgrep_present      → command -v rg (INFO-only)
+    I2 mcp_registered       → claude mcp list | grep -q obsidian  (INFO-only, best-effort)
+4. Accumulate results in an associative map (key → {status, reason?, hint?}).
+5. Format:
+     - Human mode: one line per probe + final summary, colored on TTY.
+     - JSON mode: jq-assembled object with an overall `ok` boolean.
+6. Exit 0 if every probe is OK or INFO; exit 1 if any probe is FAIL.
+```
+
+---
+
+## API / Interface Changes
+
+### New Skill
+
+| Skill | File | Invocation | Purpose |
+|-------|------|------------|---------|
+| `obsidian-memory:doctor` | `skills/doctor/SKILL.md` | `/obsidian-memory:doctor [--json]` | Read-only install-state report |
+
+### New Script
+
+| Script | File | Args | Exit code |
+|--------|------|------|-----------|
+| `vault-doctor.sh` | `scripts/vault-doctor.sh` | `[--json]` | `0` if every probe OK/INFO, `1` on any FAIL |
+
+### Human-mode output format
+
+```
+obsidian-memory doctor
+──────────────────────
+OK    config         ~/.claude/obsidian-memory/config.json
+OK    vault_path     /Users/x/Vault
+OK    jq             /opt/homebrew/bin/jq (jq-1.7)
+OK    claude         /Users/x/.local/bin/claude
+OK    sessions_dir   /Users/x/Vault/claude-memory/sessions
+OK    projects_link  /Users/x/Vault/claude-memory/projects → /Users/x/.claude/projects
+OK    rag_enabled    true
+OK    distill_enabled true
+INFO  ripgrep        /opt/homebrew/bin/rg
+INFO  mcp            obsidian server registered
+
+All checks passed.
+```
+
+Failure example:
+
+```
+obsidian-memory doctor
+──────────────────────
+OK    config         /Users/x/.claude/obsidian-memory/config.json
+FAIL  vault_path     /tmp/nope does not exist — run /obsidian-memory:setup <vault>
+OK    jq             /opt/homebrew/bin/jq
+FAIL  claude         claude not on PATH — install the Claude Code CLI
+…
+2 check(s) failed.
+```
+
+### `--json` output schema
+
+```json
+{
+  "ok": false,
+  "checks": {
+    "config":          { "status": "ok" },
+    "vault_path":      { "status": "fail", "reason": "vault path /tmp/nope does not exist", "hint": "run /obsidian-memory:setup <vault>" },
+    "jq":              { "status": "ok" },
+    "claude":          { "status": "fail", "reason": "claude not on PATH", "hint": "install the Claude Code CLI" },
+    "sessions_dir":    { "status": "ok" },
+    "projects_symlink":{ "status": "ok" },
+    "rag_enabled":     { "status": "ok" },
+    "distill_enabled": { "status": "ok" },
+    "ripgrep":         { "status": "info", "note": "vault-rag.sh will use POSIX fallback" },
+    "mcp":             { "status": "info", "note": "obsidian MCP server not registered" }
+  }
+}
+```
+
+| Code / Type | Condition |
+|-------------|-----------|
+| Exit 0 | Every probe status ∈ {`ok`, `info`} |
+| Exit 1 | ≥1 probe status is `fail` |
+
+---
+
+## Database / Storage Changes
+
+None. Doctor is read-only and introduces no persistent state.
+
+---
+
+## State Management
+
+No mutable state. Each probe produces a small record that is accumulated in a bash associative array within a single process. The process exits cleanly after emitting output.
+
+---
+
+## UI Components
+
+Not applicable (no GUI). See the output format above for terminal "UI".
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Pros | Cons | Decision |
+|--------|-------------|------|------|----------|
+| **A: Logic in SKILL.md, no script** | Let Claude orchestrate each check by calling `Bash` many times. | One file; no new script. | Not bats-testable without invoking Claude; every check becomes a separate permission prompt; slow. | Rejected — untestable and slow. |
+| **B: Pure bash script, SKILL.md is a thin wrapper** | `scripts/vault-doctor.sh` does all the work; SKILL.md tells Claude to run it. | Bats-testable end to end; fast; single permission prompt. | Two files instead of one. | **Selected**. |
+| **C: Node / Python implementation** | Richer JSON handling. | Better data structures. | Adds a runtime dep the plugin otherwise doesn't need; violates bash-first convention in `steering/tech.md`. | Rejected — stack mismatch. |
+| **D: Short-circuit on first FAIL** | Exit at the first failing probe. | Slightly faster. | Users see only one problem at a time; forces re-runs. Doctor is already sub-second, so speed is a non-issue. | Rejected — UX regression. |
+| **E: Reuse `scripts/_common.sh::om_load_config`** | Borrow the existing config loader. | DRY. | `om_load_config` calls `exit 0` on *any* failure — it's designed for hooks, not a reporter. Doctor needs to *observe* each failure, not mask it. | Rejected — different failure semantics. Doctor reads the config directly with its own probes. |
+
+---
+
+## Security Considerations
+
+- [x] **Authentication**: None required. Doctor reads only user-owned files.
+- [x] **Authorization**: The script reads only `~/.claude/obsidian-memory/config.json`, the configured `vaultPath` tree (top-level stat only), and `~/.claude/projects/` (via the symlink). No paths are accepted from the invocation environment beyond the optional `--json` flag.
+- [x] **Input Validation**: The only argument is `--json`. Any other argv value is treated as unknown and the script exits 2 with a usage line. No shell interpolation of user input.
+- [x] **Data Sanitization**: Output that includes paths from the config quotes them as plain text; no HTML, no shell echo expansion. ANSI escapes are emitted only when `stdout` is a TTY.
+- [x] **Sensitive Data**: Config contains only a vault path and enable flags — no secrets. Doctor prints the vault path (already visible via `ls`).
+
+---
+
+## Performance Considerations
+
+- [x] **Caching**: None needed. Each probe is O(1) in filesystem ops.
+- [x] **Pagination**: N/A.
+- [x] **Lazy Loading**: N/A.
+- [x] **Indexing**: N/A.
+- [x] **Wall time**: Target < 500 ms. Each probe is a `test`, `command -v`, or one `jq` invocation; worst case is ~10 fs/PATH probes plus two `jq` runs plus one optional `claude mcp list` (informational only and easy to skip if `claude` is missing).
+
+---
+
+## Testing Strategy
+
+| Layer | Type | Coverage |
+|-------|------|----------|
+| Script internals | bats unit | Not needed — probes are short and tested through integration. |
+| End-to-end | bats integration | `tests/integration/doctor.bats` with ≥1 test per failure mode, happy path, `--json`, and read-only invariant. |
+| Specification | BDD (cucumber-shell) | `specs/feature-doctor-health-check-skill/feature.gherkin` — every AC has a scenario. Step definitions in `tests/features/steps/doctor.sh`. |
+| Static | shellcheck | `scripts/vault-doctor.sh`, `tests/features/steps/doctor.sh`, any new `.bats`. |
+
+Scratch harness contract (from `tests/helpers/scratch.bash`):
+
+- `$HOME` is redirected to `$BATS_TEST_TMPDIR/home` for every test.
+- `$VAULT` and `$PLUGIN_ROOT` are pre-exported.
+- `assert_home_untouched` enforces the read-only invariant post-test by comparing a cksum digest of `~/.claude/obsidian-memory/`. Doctor tests call this in `teardown`.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| `jq` itself is missing, so probes P1/P2/P8/P9 cannot read the config | Medium | Medium | P4 (`jq_on_path`) runs before any jq-dependent probe result is finalized. If `jq` is missing, jq-dependent probes emit a degraded `SKIP` status that still prints as `FAIL: cannot check — jq missing`, so the user gets one actionable hint at the top of the report. |
+| `claude mcp list` takes a long time or prompts | Low | Low | MCP probe is INFO-only and wrapped in a short `timeout 3`. If it errors or times out, it falls back to `INFO: mcp status unknown`. |
+| `readlink -f` is not portable on macOS default bash (BSD readlink lacks `-f`) | High | Medium | Use POSIX `readlink` without `-f`; compare result to `$HOME/.claude/projects` directly. Already the pattern used in `scripts/_common.sh`. |
+| Color codes leak into pipes | Low | Low | Gate every escape sequence on `[ -t 1 ]`. |
+| Config contains an extra top-level key the probe doesn't expect | Low | Low | Probes use specific jq paths (`.vaultPath`, `.rag.enabled`, `.distill.enabled`) and default to safe values; unknown keys are ignored. |
+| Existing `om_load_config` drifts from doctor's own field reads | Medium | Low | Doctor reads `.vaultPath` directly (same key as `_common.sh` uses today). If a future change renames the key, both paths must update in lockstep; that coupling is acknowledged and called out in the SKILL.md. |
+
+---
+
+## Open Questions
+
+None remaining. Both requirements-level questions are resolved in-design (MCP status as `INFO`; `--json` includes per-check `hint`).
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #2 | 2026-04-21 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to TASKS phase:
+
+- [x] Architecture follows existing project patterns (SKILL.md + `scripts/*.sh`, per `structure.md`)
+- [x] All interface changes documented (SKILL.md invocation + script CLI + JSON schema)
+- [x] No database/storage changes required (doctor is read-only)
+- [x] No state management needed (single-process, no persistence)
+- [x] UI output defined (human + JSON formats)
+- [x] Security addressed (read-only, no untrusted interpolation)
+- [x] Performance budgeted (< 500 ms wall time)
+- [x] Testing strategy defined (bats + BDD + shellcheck)
+- [x] Alternatives documented (5 options considered)
+- [x] Risks identified with mitigations

--- a/specs/feature-doctor-health-check-skill/feature.gherkin
+++ b/specs/feature-doctor-health-check-skill/feature.gherkin
@@ -1,0 +1,96 @@
+# File: specs/feature-doctor-health-check-skill/feature.gherkin
+#
+# Generated from: specs/feature-doctor-health-check-skill/requirements.md
+# Issue: #2
+#
+# AC5 (tests run against scratch $HOME) is not a standalone scenario — it is an
+# invariant of the Background block: every scenario in this file runs under the
+# bats scratch harness (tests/helpers/scratch.bash), which redirects $HOME to
+# $BATS_TEST_TMPDIR/home before any step fires. The read-only assertion in the
+# "Doctor is read-only" scenario further proves the invariant holds end-to-end.
+
+Feature: Doctor health-check reports install state
+  As a Claude Code + Obsidian user who just installed obsidian-memory
+  I want a one-command health check that tells me whether my install is actually working
+  So that silent hook no-ops do not leave me believing memory is flowing when it isn't
+
+  Background:
+    Given a scratch $HOME at "$BATS_TEST_TMPDIR/home"
+    And   a scratch vault at "$BATS_TEST_TMPDIR/vault"
+
+  # --- Happy Path ---
+
+  Scenario: Healthy install passes all checks
+    Given a valid obsidian-memory config pointing at the scratch vault
+    And   the vault contains "claude-memory/sessions/"
+    And   the vault has a valid "claude-memory/projects" symlink to "$HOME/.claude/projects"
+    And   "jq" is on PATH
+    And   "claude" is on PATH
+    And   "rag.enabled" is true and "distill.enabled" is true in the config
+    When  I run "/obsidian-memory:doctor"
+    Then  every check line starts with "OK" or "INFO"
+    And   the output contains "All checks passed."
+    And   the exit code is 0
+
+  # --- Failure Modes (one row per failure in requirements.md AC2) ---
+
+  Scenario Outline: Specific failure modes report a remediation hint
+    Given a baseline-healthy obsidian-memory install in the scratch $HOME
+    And   <failure-condition>
+    When  I run "/obsidian-memory:doctor"
+    Then  the output contains "FAIL"
+    And   the output contains "<reason-substring>"
+    And   the output contains "<hint-substring>"
+    And   the exit code is non-zero
+
+    Examples:
+      | failure-condition                                                | reason-substring           | hint-substring                  |
+      | the config file "$HOME/.claude/obsidian-memory/config.json" is absent | config                    | /obsidian-memory:setup          |
+      | the config is present but has no "vaultPath" key                 | vaultPath                  | /obsidian-memory:setup          |
+      | "vaultPath" points at a non-existent directory                   | does not exist             | /obsidian-memory:setup          |
+      | "jq" is not on PATH                                              | jq                         | brew install jq                 |
+      | "claude" is not on PATH                                          | claude                     | Claude Code CLI                 |
+      | "claude-memory/projects" symlink is broken                       | projects                   | /obsidian-memory:setup          |
+      | "claude-memory/sessions/" does not exist                         | sessions                   | /obsidian-memory:setup          |
+      | "rag.enabled" is set to false in the config                      | rag.enabled                | /obsidian-memory:toggle rag on  |
+      | "distill.enabled" is set to false in the config                  | distill.enabled            | /obsidian-memory:toggle distill on |
+
+  # --- Read-Only Invariant ---
+
+  Scenario: Doctor is read-only across any state
+    Given a snapshot of the scratch $HOME and scratch vault trees
+    When  I run "/obsidian-memory:doctor" in the healthy state
+    And   I run "/obsidian-memory:doctor" in a partially broken state
+    And   I run "/obsidian-memory:doctor" in a fully broken state
+    Then  the tree snapshots are unchanged after every invocation
+    And   no symlink under the scratch $HOME has been created, removed, or retargeted
+
+  # --- Optional Dependencies ---
+
+  Scenario: Missing ripgrep is informational, not failing
+    Given a baseline-healthy obsidian-memory install in the scratch $HOME
+    And   "rg" is not on PATH
+    When  I run "/obsidian-memory:doctor"
+    Then  the output contains "INFO"
+    And   the output contains "ripgrep"
+    And   the exit code is 0
+
+  # --- JSON Output ---
+
+  Scenario: --json emits a machine-readable report on a healthy install
+    Given a baseline-healthy obsidian-memory install in the scratch $HOME
+    When  I run "/obsidian-memory:doctor --json"
+    Then  stdout is a single JSON object
+    And   the object has a top-level "ok" field equal to true
+    And   the object has a "checks" field containing at minimum "config", "vault_path", "jq", "claude", "sessions_dir", "projects_symlink", "rag_enabled", "distill_enabled"
+    And   the exit code is 0
+
+  Scenario: --json emits a machine-readable report on a broken install
+    Given a baseline-healthy obsidian-memory install in the scratch $HOME
+    And   "vaultPath" points at a non-existent directory
+    When  I run "/obsidian-memory:doctor --json"
+    Then  stdout is a single JSON object
+    And   the object has a top-level "ok" field equal to false
+    And   the "checks.vault_path.status" field equals "fail"
+    And   the "checks.vault_path.hint" field contains "/obsidian-memory:setup"
+    And   the exit code is non-zero

--- a/specs/feature-doctor-health-check-skill/feature.gherkin
+++ b/specs/feature-doctor-health-check-skill/feature.gherkin
@@ -8,6 +8,9 @@
 # bats scratch harness (tests/helpers/scratch.bash), which redirects $HOME to
 # $BATS_TEST_TMPDIR/home before any step fires. The read-only assertion in the
 # "Doctor is read-only" scenario further proves the invariant holds end-to-end.
+#
+# Scenario Outline is not supported by tests/run-bdd.sh, so each failure mode
+# from requirements.md AC2 (F1..F9) has an explicit Scenario below.
 
 Feature: Doctor health-check reports install state
   As a Claude Code + Obsidian user who just installed obsidian-memory
@@ -16,81 +19,134 @@ Feature: Doctor health-check reports install state
 
   Background:
     Given a scratch $HOME at "$BATS_TEST_TMPDIR/home"
-    And   a scratch vault at "$BATS_TEST_TMPDIR/vault"
+    And   a scratch Obsidian vault at "$BATS_TEST_TMPDIR/vault"
+    And   a safe PATH with a stub claude is installed
 
   # --- Happy Path ---
 
   Scenario: Healthy install passes all checks
-    Given a valid obsidian-memory config pointing at the scratch vault
-    And   the vault contains "claude-memory/sessions/"
-    And   the vault has a valid "claude-memory/projects" symlink to "$HOME/.claude/projects"
-    And   "jq" is on PATH
-    And   "claude" is on PATH
-    And   "rag.enabled" is true and "distill.enabled" is true in the config
+    Given a baseline-healthy obsidian-memory install
     When  I run "/obsidian-memory:doctor"
-    Then  every check line starts with "OK" or "INFO"
-    And   the output contains "All checks passed."
-    And   the exit code is 0
+    Then  the doctor output contains "All checks passed."
+    And   the doctor output does not contain "FAIL"
+    And   the doctor exit code is 0
 
-  # --- Failure Modes (one row per failure in requirements.md AC2) ---
+  # --- Failure Modes F1-F9 (from requirements.md AC2) ---
 
-  Scenario Outline: Specific failure modes report a remediation hint
-    Given a baseline-healthy obsidian-memory install in the scratch $HOME
-    And   <failure-condition>
+  Scenario: F1 — Config file missing reports FAIL with setup hint
+    Given no config file exists
     When  I run "/obsidian-memory:doctor"
-    Then  the output contains "FAIL"
-    And   the output contains "<reason-substring>"
-    And   the output contains "<hint-substring>"
-    And   the exit code is non-zero
+    Then  the doctor output contains "FAIL"
+    And   the doctor output contains "config"
+    And   the doctor output contains "/obsidian-memory:setup"
+    And   the doctor exit code is non-zero
 
-    Examples:
-      | failure-condition                                                | reason-substring           | hint-substring                  |
-      | the config file "$HOME/.claude/obsidian-memory/config.json" is absent | config                    | /obsidian-memory:setup          |
-      | the config is present but has no "vaultPath" key                 | vaultPath                  | /obsidian-memory:setup          |
-      | "vaultPath" points at a non-existent directory                   | does not exist             | /obsidian-memory:setup          |
-      | "jq" is not on PATH                                              | jq                         | brew install jq                 |
-      | "claude" is not on PATH                                          | claude                     | Claude Code CLI                 |
-      | "claude-memory/projects" symlink is broken                       | projects                   | /obsidian-memory:setup          |
-      | "claude-memory/sessions/" does not exist                         | sessions                   | /obsidian-memory:setup          |
-      | "rag.enabled" is set to false in the config                      | rag.enabled                | /obsidian-memory:toggle rag on  |
-      | "distill.enabled" is set to false in the config                  | distill.enabled            | /obsidian-memory:toggle distill on |
+  Scenario: F2 — vaultPath missing from config reports FAIL with setup hint
+    Given a baseline-healthy obsidian-memory install
+    And   the config has no "vaultPath" key
+    When  I run "/obsidian-memory:doctor"
+    Then  the doctor output contains "FAIL"
+    And   the doctor output contains "vaultPath"
+    And   the doctor output contains "/obsidian-memory:setup"
+    And   the doctor exit code is non-zero
+
+  Scenario: F3 — vaultPath points at a non-existent directory reports FAIL with setup hint
+    Given the config has "vaultPath" pointing at a non-existent directory
+    When  I run "/obsidian-memory:doctor"
+    Then  the doctor output contains "FAIL"
+    And   the doctor output contains "does not exist"
+    And   the doctor output contains "/obsidian-memory:setup"
+    And   the doctor exit code is non-zero
+
+  Scenario: F4 — jq missing reports FAIL with brew hint
+    Given a baseline-healthy obsidian-memory install
+    And   "jq" is not on PATH
+    When  I run "/obsidian-memory:doctor"
+    Then  the doctor output contains "FAIL"
+    And   the doctor output contains "jq"
+    And   the doctor output contains "brew install jq"
+    And   the doctor exit code is non-zero
+
+  Scenario: F5 — claude missing reports FAIL with CLI install hint
+    Given a baseline-healthy obsidian-memory install
+    And   "claude" is not on PATH
+    When  I run "/obsidian-memory:doctor"
+    Then  the doctor output contains "FAIL"
+    And   the doctor output contains "claude"
+    And   the doctor output contains "Claude Code CLI"
+    And   the doctor exit code is non-zero
+
+  Scenario: F6 — projects symlink broken reports FAIL with setup hint
+    Given a baseline-healthy obsidian-memory install
+    And   the projects symlink under the vault is broken
+    When  I run "/obsidian-memory:doctor"
+    Then  the doctor output contains "FAIL"
+    And   the doctor output contains "projects"
+    And   the doctor output contains "/obsidian-memory:setup"
+    And   the doctor exit code is non-zero
+
+  Scenario: F7 — sessions directory missing reports FAIL with setup hint
+    Given a baseline-healthy obsidian-memory install
+    And   the sessions directory under the vault is missing
+    When  I run "/obsidian-memory:doctor"
+    Then  the doctor output contains "FAIL"
+    And   the doctor output contains "sessions"
+    And   the doctor output contains "/obsidian-memory:setup"
+    And   the doctor exit code is non-zero
+
+  Scenario: F8 — rag.enabled=false reports FAIL with toggle hint
+    Given a baseline-healthy obsidian-memory install
+    And   "rag.enabled" is set to false in the config
+    When  I run "/obsidian-memory:doctor"
+    Then  the doctor output contains "FAIL"
+    And   the doctor output contains "rag.enabled"
+    And   the doctor output contains "/obsidian-memory:toggle rag on"
+    And   the doctor exit code is non-zero
+
+  Scenario: F9 — distill.enabled=false reports FAIL with toggle hint
+    Given a baseline-healthy obsidian-memory install
+    And   "distill.enabled" is set to false in the config
+    When  I run "/obsidian-memory:doctor"
+    Then  the doctor output contains "FAIL"
+    And   the doctor output contains "distill.enabled"
+    And   the doctor output contains "/obsidian-memory:toggle distill on"
+    And   the doctor exit code is non-zero
 
   # --- Read-Only Invariant ---
 
   Scenario: Doctor is read-only across any state
-    Given a snapshot of the scratch $HOME and scratch vault trees
+    Given a baseline-healthy obsidian-memory install
+    And   a snapshot of the scratch vault and obsidian-memory config is taken
     When  I run "/obsidian-memory:doctor" in the healthy state
-    And   I run "/obsidian-memory:doctor" in a partially broken state
-    And   I run "/obsidian-memory:doctor" in a fully broken state
-    Then  the tree snapshots are unchanged after every invocation
-    And   no symlink under the scratch $HOME has been created, removed, or retargeted
+    And   I run "/obsidian-memory:doctor --json" in the healthy state
+    Then  the scratch vault snapshot is unchanged
 
   # --- Optional Dependencies ---
 
   Scenario: Missing ripgrep is informational, not failing
-    Given a baseline-healthy obsidian-memory install in the scratch $HOME
+    Given a baseline-healthy obsidian-memory install
     And   "rg" is not on PATH
     When  I run "/obsidian-memory:doctor"
-    Then  the output contains "INFO"
-    And   the output contains "ripgrep"
-    And   the exit code is 0
+    Then  the doctor output contains "INFO"
+    And   the doctor output contains "ripgrep"
+    And   the doctor exit code is 0
 
   # --- JSON Output ---
 
   Scenario: --json emits a machine-readable report on a healthy install
-    Given a baseline-healthy obsidian-memory install in the scratch $HOME
+    Given a baseline-healthy obsidian-memory install
     When  I run "/obsidian-memory:doctor --json"
-    Then  stdout is a single JSON object
-    And   the object has a top-level "ok" field equal to true
-    And   the object has a "checks" field containing at minimum "config", "vault_path", "jq", "claude", "sessions_dir", "projects_symlink", "rag_enabled", "distill_enabled"
-    And   the exit code is 0
+    Then  the doctor output is a single valid JSON object
+    And   the JSON object has top-level "ok" equal to true
+    And   the JSON object has check "config" with status "ok"
+    And   the JSON object has check "vault_path" with status "ok"
+    And   the doctor exit code is 0
 
   Scenario: --json emits a machine-readable report on a broken install
-    Given a baseline-healthy obsidian-memory install in the scratch $HOME
-    And   "vaultPath" points at a non-existent directory
+    Given the config has "vaultPath" pointing at a non-existent directory
     When  I run "/obsidian-memory:doctor --json"
-    Then  stdout is a single JSON object
-    And   the object has a top-level "ok" field equal to false
-    And   the "checks.vault_path.status" field equals "fail"
-    And   the "checks.vault_path.hint" field contains "/obsidian-memory:setup"
-    And   the exit code is non-zero
+    Then  the doctor output is a single valid JSON object
+    And   the JSON object has top-level "ok" equal to false
+    And   the JSON object has check "vault_path" with status "fail"
+    And   the JSON object has check "vault_path" with hint containing "/obsidian-memory:setup"
+    And   the doctor exit code is non-zero

--- a/specs/feature-doctor-health-check-skill/requirements.md
+++ b/specs/feature-doctor-health-check-skill/requirements.md
@@ -1,0 +1,281 @@
+# Requirements: Doctor Health-Check Skill
+
+**Issues**: #2
+**Date**: 2026-04-21
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## User Story
+
+**As a** Claude Code + Obsidian user who just installed obsidian-memory
+**I want** a one-command health check that tells me whether my install is actually working
+**So that** silent hook no-ops do not leave me believing memory is flowing when it isn't
+
+---
+
+## Background
+
+The core safety principle of this plugin (`steering/product.md` → Product Principles → "Silent failure") is that every hook exits 0 on any failure mode: missing `jq`, missing `ripgrep`, missing config, disabled flag, empty input. This is deliberate — a blocking hook destroys user trust. But the same silence makes broken installs invisible: a user can install the plugin, forget to run `/obsidian-memory:setup`, and never realize their sessions are not being distilled or that their prompts are not being RAG-enriched.
+
+A dedicated `doctor` skill exposes that install state on demand, without changing the hooks' silent-on-failure behavior. The skill is a **read-only reporter** — it detects problems and prints remediation hints, but it never mutates the config, the vault, or the `~/.claude/projects/` symlink. Fixing is the job of `/obsidian-memory:setup` (already shipping) and `/obsidian-memory:toggle` (tracked as a separate v1 issue).
+
+Related context: issue #2, issue #1 (bats-core + cucumber-shell harness that this skill's tests run on).
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: Doctor passes on a healthy install
+
+**Given** `~/.claude/obsidian-memory/config.json` exists with a valid `vaultPath` pointing at a real directory
+**And** `jq` is on `PATH` and `claude` is on `PATH`
+**And** `<vault>/claude-memory/sessions/` exists and `<vault>/claude-memory/projects` is a symlink resolving to `~/.claude/projects`
+**And** `rag.enabled` and `distill.enabled` are `true` (or unset, which the scripts treat as enabled)
+**When** the user runs `/obsidian-memory:doctor`
+**Then** the skill reports `OK` for every check with a green-style summary line
+**And** the skill exits 0
+
+**Example**:
+- Given: scratch `$HOME` with a valid config pointing at `$BATS_TEST_TMPDIR/vault`, which contains `claude-memory/sessions/` and a valid `claude-memory/projects` symlink
+- When: the doctor script is invoked
+- Then: stdout shows one `OK` line per check and a final `All checks passed.` summary; exit code is 0
+
+### AC2: Doctor reports each specific failure mode with a one-line remediation hint
+
+**Given** one of the failure modes below is in effect
+**When** the user runs `/obsidian-memory:doctor`
+**Then** the skill prints `FAIL: <what's wrong> — <one-line remediation hint>` for that check
+**And** the skill exits non-zero
+
+Failure modes (each becomes its own Gherkin scenario via Scenario Outline):
+
+| # | Failure mode | Example remediation hint |
+|---|--------------|--------------------------|
+| F1 | Config file missing | `run /obsidian-memory:setup <vault>` |
+| F2 | `vaultPath` missing from config | `run /obsidian-memory:setup <vault>` |
+| F3 | `vaultPath` is not a directory | `vault path <path> does not exist — run /obsidian-memory:setup <vault>` |
+| F4 | `jq` not on PATH | `brew install jq` (or platform equivalent) |
+| F5 | `claude` not on PATH | `install the Claude Code CLI; see https://docs.claude.com/claude-code` |
+| F6 | `claude-memory/projects` symlink broken or missing | `run /obsidian-memory:setup <vault>` |
+| F7 | `claude-memory/sessions/` missing | `run /obsidian-memory:setup <vault>` |
+| F8 | `rag.enabled` is `false` in config | `run /obsidian-memory:toggle rag on` |
+| F9 | `distill.enabled` is `false` in config | `run /obsidian-memory:toggle distill on` |
+
+### AC3: Doctor is read-only — it never mutates state
+
+**Given** any combination of healthy and broken checks
+**When** the user runs `/obsidian-memory:doctor`
+**Then** no file is created, modified, or deleted under `~/.claude/obsidian-memory/`, the vault, or `~/.claude/projects/`
+**And** no symlink is created, removed, or retargeted
+
+**Example**:
+- Given: a scratch `$HOME` snapshot of every mtime under `$HOME/.claude/obsidian-memory/` and the scratch vault
+- When: the doctor runs (in healthy, partially-broken, and fully-broken states)
+- Then: the mtime snapshot matches exactly afterward — no inode or content diff
+
+### AC4: Optional dependencies surface as informational, not failing
+
+**Given** `ripgrep` (`rg`) is not on `PATH` but everything else is healthy
+**When** the user runs `/obsidian-memory:doctor`
+**Then** the skill prints an informational line: `INFO: ripgrep not on PATH — vault-rag.sh will use POSIX fallback`
+**And** the skill exits 0 (not a failure)
+
+### AC5: Doctor runs against a scratch `$HOME` in tests
+
+**Given** the bats integration harness (issue #1)
+**When** the doctor integration test runs
+**Then** it reads and writes only under `$BATS_TEST_TMPDIR`
+**And** it never touches the operator's real `~/.claude/` or real vault
+
+### AC6: `--json` flag emits a machine-readable report
+
+**Given** a healthy install
+**When** the user runs `/obsidian-memory:doctor --json`
+**Then** stdout is a single JSON object with one key per check (e.g., `config`, `vault_path`, `jq`, `claude`, `sessions_dir`, `projects_symlink`, `rag_enabled`, `distill_enabled`, `ripgrep`) and a top-level `ok` boolean
+**And** each check value is one of `"ok"`, `"fail"`, or `"info"`
+**And** exit code matches: 0 when `ok` is `true`, non-zero otherwise
+
+---
+
+### Generated Gherkin Preview
+
+```gherkin
+Feature: Doctor health-check reports install state
+  As a Claude Code + Obsidian user who just installed obsidian-memory
+  I want a one-command health check that tells me whether my install is working
+  So that silent hook no-ops do not leave me believing memory is flowing when it isn't
+
+  Scenario: Healthy install passes all checks
+    Given a healthy obsidian-memory install in a scratch $HOME
+    When I run /obsidian-memory:doctor
+    Then every check reports OK
+    And the exit code is 0
+
+  Scenario Outline: Specific failure modes report a remediation hint
+    Given <failure-mode> in a scratch $HOME
+    When I run /obsidian-memory:doctor
+    Then the output contains "FAIL: <reason>"
+    And the output contains "<hint>"
+    And the exit code is non-zero
+    Examples:
+      | failure-mode              | reason                          | hint                               |
+      | missing config            | config file missing             | /obsidian-memory:setup             |
+      | vaultPath missing         | vaultPath missing from config   | /obsidian-memory:setup             |
+      | vaultPath not a directory | vault path does not exist       | /obsidian-memory:setup             |
+      | jq not on PATH            | jq not on PATH                  | brew install jq                    |
+      | claude not on PATH        | claude not on PATH              | Claude Code CLI                    |
+      | projects symlink broken   | projects symlink                | /obsidian-memory:setup             |
+      | sessions dir missing      | sessions directory              | /obsidian-memory:setup             |
+      | rag disabled              | rag.enabled is false            | /obsidian-memory:toggle rag on     |
+      | distill disabled          | distill.enabled is false        | /obsidian-memory:toggle distill on |
+
+  Scenario: Doctor is read-only
+    Given a snapshot of every mtime under the scratch $HOME
+    When I run /obsidian-memory:doctor in any state
+    Then no file or symlink under the scratch $HOME is created, modified, or removed
+
+  Scenario: ripgrep missing is informational, not failing
+    Given a healthy install but ripgrep is not on PATH
+    When I run /obsidian-memory:doctor
+    Then the output contains "INFO: ripgrep"
+    And the exit code is 0
+
+  Scenario: --json emits a machine-readable report
+    Given a healthy install
+    When I run /obsidian-memory:doctor --json
+    Then stdout is a single JSON object
+    And the object has an "ok" boolean equal to true
+    And the exit code is 0
+```
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR1 | Add `skills/doctor/SKILL.md` following the skill template in `steering/structure.md`. | Must | Issue body says `plugins/obsidian-memory/skills/doctor/SKILL.md` — this repo is a standalone plugin, so skills live at `skills/` (see `structure.md` → Project Layout). |
+| FR2 | Implement the health checks listed in AC2 as pure read-only probes in a shell script under `scripts/`. | Must | The SKILL.md delegates to a script so the logic is bats-testable without invoking Claude. |
+| FR3 | Exit code 0 if all checks pass, non-zero if any fail. Specific exit code does not need to encode which check failed — the summary output does that. | Must | |
+| FR4 | Human-readable output: one line per check, `OK: <check-name>` or `FAIL: <reason> — <hint>` or `INFO: <note>`. Summary line at the end. | Must | |
+| FR5 | Machine-readable output via `--json` flag: a JSON object with one key per check and an overall `ok` boolean. | Should | |
+| FR6 | BDD scenarios for the happy path, each failure mode, read-only property, `--json` output, and optional-dep informational path. | Must | Lives at `specs/feature-doctor-health-check-skill/feature.gherkin`. |
+| FR7 | Detect optional dependencies (`ripgrep`) and surface them as `INFO`, not `FAIL`. MCP registration is also informational. | Should | Optional deps do not gate a `0` exit. |
+| FR8 | Color-coded output when stdout is a TTY; plain when piped. | Could | Use `[ -t 1 ]` to decide. ANSI escape codes are standard — no extra dependency. |
+| FR9 | Output vocabulary is consistent with `/obsidian-memory:setup` ("vault path", "config", "symlink"). | Should | Reduces cognitive load across skills. |
+
+---
+
+## Non-Functional Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Performance** | Wall time < 500 ms in the common case; no network calls; no `claude -p` subprocess. |
+| **Security** | Read-only against config, vault, and `~/.claude/projects/`. No write syscalls. No subprocess other than `jq`, `test`, `readlink`, `command -v`. |
+| **Accessibility** | Plain-text output works in every terminal. Color is an enhancement, not a requirement. |
+| **Reliability** | Doctor itself must not fail — a crash in doctor is worse than silent hook failure. Wrap unknown failure paths so the script always prints something and exits with a deterministic code. |
+| **Platforms** | macOS default bash (3.2) and Linux bash 4+, per `steering/tech.md`. |
+
+---
+
+## UI/UX Requirements
+
+Doctor has no GUI. Its "UI" is terminal output.
+
+| Element | Requirement |
+|---------|-------------|
+| **Structure** | One line per check. Final summary line. Optional remediation hints on `FAIL` lines. |
+| **Vocabulary** | Reuse terms from `setup` ("vault path", "config", "projects symlink", "sessions directory"). |
+| **Color (TTY only)** | `OK` green, `FAIL` red, `INFO` yellow, summary in bold. Never colorize when `stdout` is piped. |
+| **Empty state** | Not applicable — there is always at least one check to report. |
+| **Error state** | If doctor itself cannot run (e.g., bash is missing), that is outside its scope. |
+
+---
+
+## Data Requirements
+
+### Input Data
+
+| Field | Type | Validation | Required |
+|-------|------|------------|----------|
+| `--json` flag | CLI flag | Presence only | No |
+
+### Output Data
+
+| Field | Type | Description |
+|-------|------|-------------|
+| stdout (human mode) | plain text | One line per check; final summary |
+| stdout (JSON mode) | JSON object | One key per check + `ok` boolean |
+| Exit code | int | 0 on success, non-zero on any `FAIL` |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+
+- [x] `scripts/_common.sh` — may be partially reused for config-loading helpers (read-only subset only)
+- [x] `/obsidian-memory:setup` — doctor references setup in its remediation hints
+
+### External Dependencies
+
+- [x] `jq` — required at runtime (doctor checks for its presence before using it; if `jq` is missing, that becomes a FAIL with a hint rather than a crash)
+- [ ] `ripgrep` — optional, informational
+
+### Blocked By
+
+- None. Issue #1 (bats-core harness) is already merged and available for the tests.
+
+---
+
+## Out of Scope
+
+- **Auto-fixing any detected problem.** Doctor is strictly a reporter. Fixing belongs to `/obsidian-memory:setup` (already exists) or `/obsidian-memory:toggle` (issue #4).
+- **Live RAG retrieval assertion** — checking that `vault-rag.sh` actually returns matches for a live prompt is covered by the integration tests from issue #1, not by doctor.
+- **Remote version check** — comparing the installed version against the upstream nmg-plugins version. Tracked separately if ever needed.
+- **Teardown verification** — doctor does not validate that `/obsidian-memory:teardown` has run cleanly; that belongs in its own skill.
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Reported install-state accuracy | 100% for the 9 failure modes in AC2 | Integration test per failure mode asserts `FAIL` line and non-zero exit |
+| Read-only invariant holds | 100% across a full scenario matrix | Pre/post mtime snapshot in a bats test |
+| Doctor self-reliability | Zero crash reports (unhandled `set -u` or trap firings) | Covered by bats test against missing-everything scratch `$HOME` |
+
+---
+
+## Open Questions
+
+- [ ] Should the `INFO:` lines for optional deps also include the MCP server registration status? (Recommended: yes; it matches user mental model.) — Resolved in design as *yes*, surfaced as `INFO`.
+- [ ] Should `--json` output include the remediation hint text, or only `"fail"`? (Recommended: include `hint` field per check; cheap to add, useful for scripts.) — Resolved in design as *include `hint`*.
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #2 | 2026-04-21 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to PLAN phase:
+
+- [x] User story follows "As a / I want / So that" format
+- [x] All acceptance criteria use Given/When/Then format
+- [x] No implementation details in requirements (design.md will cover how)
+- [x] All criteria are testable and unambiguous
+- [x] Success metrics are measurable
+- [x] Edge cases (read-only, optional deps, JSON output) are specified
+- [x] Dependencies are identified
+- [x] Out of scope is defined
+- [x] Open questions are documented

--- a/specs/feature-doctor-health-check-skill/requirements.md
+++ b/specs/feature-doctor-health-check-skill/requirements.md
@@ -99,58 +99,7 @@ Failure modes (each becomes its own Gherkin scenario via Scenario Outline):
 **And** each check value is one of `"ok"`, `"fail"`, or `"info"`
 **And** exit code matches: 0 when `ok` is `true`, non-zero otherwise
 
----
-
-### Generated Gherkin Preview
-
-```gherkin
-Feature: Doctor health-check reports install state
-  As a Claude Code + Obsidian user who just installed obsidian-memory
-  I want a one-command health check that tells me whether my install is working
-  So that silent hook no-ops do not leave me believing memory is flowing when it isn't
-
-  Scenario: Healthy install passes all checks
-    Given a healthy obsidian-memory install in a scratch $HOME
-    When I run /obsidian-memory:doctor
-    Then every check reports OK
-    And the exit code is 0
-
-  Scenario Outline: Specific failure modes report a remediation hint
-    Given <failure-mode> in a scratch $HOME
-    When I run /obsidian-memory:doctor
-    Then the output contains "FAIL: <reason>"
-    And the output contains "<hint>"
-    And the exit code is non-zero
-    Examples:
-      | failure-mode              | reason                          | hint                               |
-      | missing config            | config file missing             | /obsidian-memory:setup             |
-      | vaultPath missing         | vaultPath missing from config   | /obsidian-memory:setup             |
-      | vaultPath not a directory | vault path does not exist       | /obsidian-memory:setup             |
-      | jq not on PATH            | jq not on PATH                  | brew install jq                    |
-      | claude not on PATH        | claude not on PATH              | Claude Code CLI                    |
-      | projects symlink broken   | projects symlink                | /obsidian-memory:setup             |
-      | sessions dir missing      | sessions directory              | /obsidian-memory:setup             |
-      | rag disabled              | rag.enabled is false            | /obsidian-memory:toggle rag on     |
-      | distill disabled          | distill.enabled is false        | /obsidian-memory:toggle distill on |
-
-  Scenario: Doctor is read-only
-    Given a snapshot of every mtime under the scratch $HOME
-    When I run /obsidian-memory:doctor in any state
-    Then no file or symlink under the scratch $HOME is created, modified, or removed
-
-  Scenario: ripgrep missing is informational, not failing
-    Given a healthy install but ripgrep is not on PATH
-    When I run /obsidian-memory:doctor
-    Then the output contains "INFO: ripgrep"
-    And the exit code is 0
-
-  Scenario: --json emits a machine-readable report
-    Given a healthy install
-    When I run /obsidian-memory:doctor --json
-    Then stdout is a single JSON object
-    And the object has an "ok" boolean equal to true
-    And the exit code is 0
-```
+See [feature.gherkin](feature.gherkin) for the canonical BDD scenarios.
 
 ---
 
@@ -253,8 +202,8 @@ Doctor has no GUI. Its "UI" is terminal output.
 
 ## Open Questions
 
-- [ ] Should the `INFO:` lines for optional deps also include the MCP server registration status? (Recommended: yes; it matches user mental model.) — Resolved in design as *yes*, surfaced as `INFO`.
-- [ ] Should `--json` output include the remediation hint text, or only `"fail"`? (Recommended: include `hint` field per check; cheap to add, useful for scripts.) — Resolved in design as *include `hint`*.
+- [x] Should the `INFO:` lines for optional deps also include the MCP server registration status? (Recommended: yes; it matches user mental model.) — Resolved in design as *yes*, surfaced as `INFO`.
+- [x] Should `--json` output include the remediation hint text, or only `"fail"`? (Recommended: include `hint` field per check; cheap to add, useful for scripts.) — Resolved in design as *include `hint`*.
 
 ---
 

--- a/specs/feature-doctor-health-check-skill/tasks.md
+++ b/specs/feature-doctor-health-check-skill/tasks.md
@@ -13,12 +13,11 @@
 |-------|-------|--------|
 | Setup | 1 | [ ] |
 | Backend | 2 | [ ] |
-| Frontend | 0 | [ ] |
 | Integration | 1 | [ ] |
 | Testing | 3 | [ ] |
 | **Total** | 7 | |
 
-"Backend" here means the shell implementation; "Integration" means the user-facing skill wrapper. obsidian-memory has no UI layer, so Phase 3 is intentionally empty.
+"Backend" means the shell implementation; "Integration" means the user-facing skill wrapper.
 
 ---
 
@@ -95,13 +94,7 @@
 
 ---
 
-## Phase 3: Frontend Implementation
-
-*Not applicable — obsidian-memory has no UI layer. The skill wrapper is the user-facing surface and is covered under Phase 4.*
-
----
-
-## Phase 4: Integration
+## Phase 3: Integration
 
 ### T004: Write `skills/doctor/SKILL.md`
 

--- a/specs/feature-doctor-health-check-skill/tasks.md
+++ b/specs/feature-doctor-health-check-skill/tasks.md
@@ -1,0 +1,210 @@
+# Tasks: Doctor Health-Check Skill
+
+**Issues**: #2
+**Date**: 2026-04-21
+**Status**: Planning
+**Author**: Rich Nunley
+
+---
+
+## Summary
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Setup | 1 | [ ] |
+| Backend | 2 | [ ] |
+| Frontend | 0 | [ ] |
+| Integration | 1 | [ ] |
+| Testing | 3 | [ ] |
+| **Total** | 7 | |
+
+"Backend" here means the shell implementation; "Integration" means the user-facing skill wrapper. obsidian-memory has no UI layer, so Phase 3 is intentionally empty.
+
+---
+
+## Task Format
+
+```
+### T[NNN]: [Task Title]
+
+**File(s)**: `path/to/file`
+**Type**: Create | Modify
+**Depends**: T[NNN] (or None)
+**Acceptance**:
+- [ ] [Verifiable criterion]
+```
+
+---
+
+## Phase 1: Setup
+
+### T001: Create feature directory structure
+
+**File(s)**: `skills/doctor/`, `scripts/`, `tests/integration/`, `tests/features/steps/`
+**Type**: Create (directories only; actual files created in later tasks)
+**Depends**: None
+**Acceptance**:
+- [ ] `skills/doctor/` exists (empty, ready for SKILL.md in T005)
+- [ ] `scripts/` and `tests/integration/` and `tests/features/steps/` already exist from prior work — verify presence, create if missing
+
+**Notes**: Low-risk directory prep task. Combines creation with presence verification so the task is safely idempotent.
+
+---
+
+## Phase 2: Backend Implementation
+
+### T002: Implement `vault-doctor.sh` probes and human-readable output
+
+**File(s)**: `scripts/vault-doctor.sh`
+**Type**: Create
+**Depends**: T001
+**Acceptance**:
+- [ ] Shebang `#!/usr/bin/env bash`; `set -u`; `trap` at top level per `steering/tech.md` Bash standards
+- [ ] Accepts `--json` flag; anything else prints a short usage line and exits 2
+- [ ] Runs every probe P1–P9 and I1–I2 from `design.md` → Data Flow, in order, without short-circuiting
+- [ ] Probe P1 (config) reads `$HOME/.claude/obsidian-memory/config.json`
+- [ ] Probes P2/P8/P9 use `jq` on `.vaultPath`, `.rag.enabled`, `.distill.enabled`; treat unset `.rag.enabled`/`.distill.enabled` as enabled (matches `_common.sh` behavior)
+- [ ] Probe P7 uses plain `readlink` (no `-f`) and compares the target to `$HOME/.claude/projects`; works under BSD readlink on macOS
+- [ ] Probe I1 reports `INFO` when `rg` is missing, never `FAIL`
+- [ ] Probe I2 runs `claude mcp list` under `timeout 3`, treats non-zero/timeouts as `INFO: mcp status unknown`
+- [ ] When `jq` itself is missing, jq-dependent probes degrade to `FAIL: cannot check — jq missing` (do not crash)
+- [ ] Human output format matches the sample in `design.md` → Human-mode output format
+- [ ] ANSI color codes emitted only when `[ -t 1 ]`
+- [ ] Exits 0 when every probe status ∈ {`ok`, `info`}; exits 1 on any `fail`
+- [ ] File is read-only at runtime — no `>`, `>>`, `mv`, `rm`, `ln`, or `mkdir` anywhere in the script
+- [ ] Passes `shellcheck scripts/vault-doctor.sh`
+
+**Notes**: Do NOT reuse `scripts/_common.sh::om_load_config` — it exits 0 on any failure, which masks the diagnoses doctor must surface. Doctor reads the config directly. Rationale is captured under Alternatives Considered → Option E in `design.md`.
+
+### T003: Add `--json` output mode to `vault-doctor.sh`
+
+**File(s)**: `scripts/vault-doctor.sh` (same script, extends T002)
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] When invoked with `--json`, stdout is a single valid JSON object (pipes through `jq empty` without error)
+- [ ] Object shape matches the schema in `design.md` → `--json` output schema
+- [ ] Per-check `status` ∈ {`ok`, `fail`, `info`}
+- [ ] `FAIL` checks include both `reason` and `hint` fields
+- [ ] `INFO` checks include a `note` field
+- [ ] Top-level `ok` boolean is `true` iff every status ∈ {`ok`, `info`}
+- [ ] Color codes are suppressed in JSON mode (stdout must be pure JSON)
+- [ ] Exit code policy matches human mode
+
+**Notes**: Keep JSON assembly in a single `jq -n` call at the end — easier to verify and hardens against bash string-quoting bugs.
+
+---
+
+## Phase 3: Frontend Implementation
+
+*Not applicable — obsidian-memory has no UI layer. The skill wrapper is the user-facing surface and is covered under Phase 4.*
+
+---
+
+## Phase 4: Integration
+
+### T004: Write `skills/doctor/SKILL.md`
+
+**File(s)**: `skills/doctor/SKILL.md`
+**Type**: Create
+**Depends**: T002, T003
+**Acceptance**:
+- [ ] Frontmatter follows the template in `steering/structure.md` → File Templates → Skill template
+- [ ] `name: doctor`, `description:` includes trigger phrases ("check obsidian-memory install", "is my obsidian-memory setup working", "diagnose obsidian-memory", "health check obsidian-memory", "/obsidian-memory:doctor")
+- [ ] `allowed-tools: Bash, Read` (no Write / Edit — enforces read-only UX)
+- [ ] `model: sonnet`, `effort: low` (matches `setup` and `distill-session`)
+- [ ] Body documents the `--json` flag, the read-only guarantee, and lists each check with its remediation hint
+- [ ] "When to Use" and "When NOT to Use" sections present
+- [ ] Instructs Claude to invoke `"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/obsidian-memory}/scripts/vault-doctor.sh"` (with `"$@"`), relay the script's exit code and output verbatim, and never call the script twice in one invocation
+- [ ] Mentions that `/obsidian-memory:setup`'s success message should point users here (documentation cross-link)
+
+**Notes**: The SKILL.md is intentionally thin. Claude shells out to the script and reports back — it does not re-interpret the results. This preserves the bats-testable contract for the underlying probes.
+
+---
+
+## Phase 5: BDD Testing (Required)
+
+**Every acceptance criterion MUST have a Gherkin scenario.**
+
+### T005: Write BDD feature file
+
+**File(s)**: `specs/feature-doctor-health-check-skill/feature.gherkin`
+**Type**: Create
+**Depends**: None (can be drafted in parallel with T002)
+**Acceptance**:
+- [ ] One scenario per AC from `requirements.md`:
+  - AC1 → `Scenario: Healthy install passes all checks`
+  - AC2 → `Scenario Outline: Specific failure modes report a remediation hint` (9 rows)
+  - AC3 → `Scenario: Doctor is read-only`
+  - AC4 → `Scenario: ripgrep missing is informational`
+  - AC6 → `Scenario: --json emits a machine-readable report`
+- [ ] AC5 (scratch `$HOME`) is covered by the `Background:` that declares the scratch harness, not a standalone scenario — rationale noted as a comment in the feature file
+- [ ] Valid Gherkin syntax — `tests/run-bdd.sh` parses the file without error
+- [ ] Uses declarative phrasing ("I run /obsidian-memory:doctor"), not implementation details
+
+### T006: Implement step definitions
+
+**File(s)**: `tests/features/steps/doctor.sh`
+**Type**: Create
+**Depends**: T002, T003, T005
+**Acceptance**:
+- [ ] One step definition per unique Given/When/Then phrase in `feature.gherkin`
+- [ ] Step definitions follow the naming convention in `steering/tech.md` → Step Definitions (function name mirrors the step phrasing, `lower_snake_case`)
+- [ ] All filesystem state lives under `$BATS_TEST_TMPDIR` per the scratch harness contract
+- [ ] Invokes the script under test via `"$PLUGIN_ROOT/scripts/vault-doctor.sh"`
+- [ ] `tests/run-bdd.sh` passes with every scenario green
+- [ ] Passes `shellcheck tests/features/steps/doctor.sh`
+
+### T007: Add bats integration test
+
+**File(s)**: `tests/integration/doctor.bats`
+**Type**: Create
+**Depends**: T002, T003
+**Acceptance**:
+- [ ] `setup()` loads `../helpers/scratch`; `teardown()` calls `assert_home_untouched`
+- [ ] One `@test` for the happy path (all probes OK/INFO, exit 0)
+- [ ] One `@test` per failure mode F1–F9 (9 tests) asserting the right `FAIL:` line and non-zero exit
+- [ ] One `@test` that runs `vault-doctor.sh --json` and pipes the output through `jq empty` plus an `ok: false` assertion in a broken state and `ok: true` in a healthy state
+- [ ] One `@test` for the optional-deps path (ripgrep on a hidden `PATH`) — output contains `INFO: ripgrep`, exit 0
+- [ ] One `@test` for the read-only invariant — pre-/post-snapshot of the scratch `$VAULT` directory tree matches exactly, in addition to the standard `assert_home_untouched` teardown check
+- [ ] `bats tests/integration/doctor.bats` passes
+
+**Notes**: Hide `ripgrep` from a test by prepending a scratch-dir-only `PATH`. Avoid using `sudo` or modifying the real `PATH` beyond the test process. The `claude mcp list` informational probe should be mocked via the existing `tests/helpers/fake-claude.bash` helper or by stubbing `claude` in the scratch `PATH` — whichever is simpler given the harness's current stub conventions.
+
+---
+
+## Dependency Graph
+
+```
+T001 ──┬──▶ T002 ──┬──▶ T003 ──┬──▶ T004
+       │                       │
+       │                       └──▶ T007
+       │
+       └──▶ T005 ──▶ T006
+```
+
+Critical path: T001 → T002 → T003 → T004 (user-invocable feature reaches the skill surface).
+Independent track: T005 can begin once requirements.md is approved; T006 joins once T005 and T003 both land.
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #2 | 2026-04-21 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to IMPLEMENT phase:
+
+- [x] Each task has single responsibility
+- [x] Dependencies are correctly mapped
+- [x] Tasks can be completed independently (given dependencies)
+- [x] Acceptance criteria are verifiable
+- [x] File paths reference actual project structure (per `steering/structure.md`)
+- [x] Test tasks are included for each implementation task
+- [x] No circular dependencies
+- [x] Tasks are in logical execution order

--- a/tests/features/steps/doctor.sh
+++ b/tests/features/steps/doctor.sh
@@ -1,5 +1,5 @@
 # tests/features/steps/doctor.sh — step definitions for
-# specs/feature-doctor-health-check-skill/feature.gherkin (#2).
+# specs/feature-doctor-health-check-skill/feature.gherkin.
 #
 # Exercises scripts/vault-doctor.sh end-to-end against the scratch harness.
 # No real mutation of the operator's $HOME; all state lives under
@@ -14,14 +14,10 @@ D_STDERR=""
 D_RC=0
 D_SNAPSHOT=""
 
-_doctor_config() {
-  printf '%s' "$HOME/.claude/obsidian-memory/config.json"
-}
-
 _doctor_write_config() {
   local rag="$1" distill="$2"
   local cfg
-  cfg="$(_doctor_config)"
+  cfg="$(_config_path)"
   mkdir -p "$(dirname "$cfg")"
   cat > "$cfg" <<EOF
 {"vaultPath":"$VAULT","rag":{"enabled":$rag},"distill":{"enabled":$distill}}
@@ -80,11 +76,7 @@ _doctor_tree_digest() {
 
 _doctor_run() {
   D_STDERR="$(mktemp "$BATS_TEST_TMPDIR/doctor.err.XXXXXX")"
-  if [ -n "${1:-}" ]; then
-    D_STDOUT="$("$PLUGIN_ROOT/scripts/vault-doctor.sh" "$1" 2>"$D_STDERR")"
-  else
-    D_STDOUT="$("$PLUGIN_ROOT/scripts/vault-doctor.sh" 2>"$D_STDERR")"
-  fi
+  D_STDOUT="$("$PLUGIN_ROOT/scripts/vault-doctor.sh" "$@" 2>"$D_STDERR")"
   D_RC=$?
 }
 
@@ -102,16 +94,16 @@ given_a_baseline_healthy_obsidian_memory_install() {
 }
 
 given_no_config_file_exists() {
-  rm -f "$(_doctor_config)"
-  [ ! -e "$(_doctor_config)" ]
+  rm -f "$(_config_path)"
+  [ ! -e "$(_config_path)" ]
 }
 
 given_the_config_has_no_key() {
   # Arg: "vaultPath"
   local key="${1:-vaultPath}"
-  mkdir -p "$(dirname "$(_doctor_config)")"
+  mkdir -p "$(dirname "$(_config_path)")"
   # Write a config with everything EXCEPT the specified key.
-  cat > "$(_doctor_config)" <<EOF
+  cat > "$(_config_path)" <<EOF
 {"rag":{"enabled":true},"distill":{"enabled":true}}
 EOF
   # Guard against unused-arg warnings.
@@ -120,8 +112,8 @@ EOF
 
 given_the_config_has_pointing_at_a_non_existent_directory() {
   # Arg: "vaultPath" (literal) — the key whose value should be bogus.
-  mkdir -p "$(dirname "$(_doctor_config)")"
-  cat > "$(_doctor_config)" <<EOF
+  mkdir -p "$(dirname "$(_config_path)")"
+  cat > "$(_config_path)" <<EOF
 {"vaultPath":"$BATS_TEST_TMPDIR/does-not-exist","rag":{"enabled":true},"distill":{"enabled":true}}
 EOF
 }
@@ -164,7 +156,7 @@ given_a_snapshot_of_the_scratch_vault_and_obsidian_memory_config_is_taken() {
 when_i_run() {
   local cmd="${1:-}"
   case "$cmd" in
-    "/obsidian-memory:doctor")        _doctor_run "" ;;
+    "/obsidian-memory:doctor")        _doctor_run ;;
     "/obsidian-memory:doctor --json") _doctor_run "--json" ;;
     *) return 1 ;;
   esac

--- a/tests/features/steps/doctor.sh
+++ b/tests/features/steps/doctor.sh
@@ -1,0 +1,230 @@
+# tests/features/steps/doctor.sh — step definitions for
+# specs/feature-doctor-health-check-skill/feature.gherkin (#2).
+#
+# Exercises scripts/vault-doctor.sh end-to-end against the scratch harness.
+# No real mutation of the operator's $HOME; all state lives under
+# $BATS_TEST_TMPDIR.
+
+# shellcheck shell=bash
+# shellcheck disable=SC2154,SC2153
+
+# Per-scenario state.
+D_STDOUT=""
+D_STDERR=""
+D_RC=0
+D_SNAPSHOT=""
+
+_doctor_config() {
+  printf '%s' "$HOME/.claude/obsidian-memory/config.json"
+}
+
+_doctor_write_config() {
+  local rag="$1" distill="$2"
+  local cfg
+  cfg="$(_doctor_config)"
+  mkdir -p "$(dirname "$cfg")"
+  cat > "$cfg" <<EOF
+{"vaultPath":"$VAULT","rag":{"enabled":$rag},"distill":{"enabled":$distill}}
+EOF
+}
+
+_doctor_install_safe_path_with_stub_claude() {
+  local bindir="$BATS_TEST_TMPDIR/doctorbin"
+  [ -f "$bindir/.initialized" ] && { PATH="$bindir"; export PATH; return 0; }
+
+  mkdir -p "$bindir"
+  local d f name
+  local IFS_SAVED="$IFS"
+  IFS=':'
+  for d in $PATH; do
+    [ -d "$d" ] || continue
+    for f in "$d"/*; do
+      [ -x "$f" ] || continue
+      name="$(basename "$f")"
+      [ -e "$bindir/$name" ] && continue
+      ln -s "$f" "$bindir/$name" 2>/dev/null || true
+    done
+  done
+  IFS="$IFS_SAVED"
+
+  rm -f "$bindir/claude"
+  cat > "$bindir/claude" <<'CLAUDE'
+#!/usr/bin/env bash
+if [ "${1:-}" = "mcp" ] && [ "${2:-}" = "list" ]; then
+  echo "obsidian: ws://localhost:22360"
+  exit 0
+fi
+exit 0
+CLAUDE
+  chmod +x "$bindir/claude"
+
+  : > "$bindir/.initialized"
+
+  PATH="$bindir"
+  export PATH
+}
+
+_doctor_baseline_healthy() {
+  _doctor_write_config true true
+  mkdir -p "$VAULT/claude-memory/sessions"
+  mkdir -p "$HOME/.claude/projects"
+  ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+}
+
+_doctor_tree_digest() {
+  find "$VAULT" "$HOME/.claude/obsidian-memory" -print0 2>/dev/null \
+    | LC_ALL=C sort -z \
+    | xargs -0 cksum 2>/dev/null \
+    | LC_ALL=C sort
+}
+
+_doctor_run() {
+  D_STDERR="$(mktemp "$BATS_TEST_TMPDIR/doctor.err.XXXXXX")"
+  if [ -n "${1:-}" ]; then
+    D_STDOUT="$("$PLUGIN_ROOT/scripts/vault-doctor.sh" "$1" 2>"$D_STDERR")"
+  else
+    D_STDOUT="$("$PLUGIN_ROOT/scripts/vault-doctor.sh" 2>"$D_STDERR")"
+  fi
+  D_RC=$?
+}
+
+# ------------------------------------------------------------
+# Given steps
+# ------------------------------------------------------------
+
+given_a_safe_path_with_a_stub_claude_is_installed() {
+  _doctor_install_safe_path_with_stub_claude
+}
+
+given_a_baseline_healthy_obsidian_memory_install() {
+  _doctor_install_safe_path_with_stub_claude
+  _doctor_baseline_healthy
+}
+
+given_no_config_file_exists() {
+  rm -f "$(_doctor_config)"
+  [ ! -e "$(_doctor_config)" ]
+}
+
+given_the_config_has_no_key() {
+  # Arg: "vaultPath"
+  local key="${1:-vaultPath}"
+  mkdir -p "$(dirname "$(_doctor_config)")"
+  # Write a config with everything EXCEPT the specified key.
+  cat > "$(_doctor_config)" <<EOF
+{"rag":{"enabled":true},"distill":{"enabled":true}}
+EOF
+  # Guard against unused-arg warnings.
+  [ -n "$key" ]
+}
+
+given_the_config_has_pointing_at_a_non_existent_directory() {
+  # Arg: "vaultPath" (literal) — the key whose value should be bogus.
+  mkdir -p "$(dirname "$(_doctor_config)")"
+  cat > "$(_doctor_config)" <<EOF
+{"vaultPath":"$BATS_TEST_TMPDIR/does-not-exist","rag":{"enabled":true},"distill":{"enabled":true}}
+EOF
+}
+
+given_is_not_on_path() {
+  # Arg: binary name ("jq" / "claude" / "rg").
+  local bin="${1:-}"
+  [ -n "$bin" ] || return 1
+  rm -f "$BATS_TEST_TMPDIR/doctorbin/$bin"
+  ! command -v "$bin" >/dev/null 2>&1
+}
+
+given_the_projects_symlink_under_the_vault_is_broken() {
+  rm -f "$VAULT/claude-memory/projects"
+  ln -s "$BATS_TEST_TMPDIR/nonexistent-target" "$VAULT/claude-memory/projects"
+}
+
+given_the_sessions_directory_under_the_vault_is_missing() {
+  rm -rf "$VAULT/claude-memory/sessions"
+}
+
+given_is_set_to_false_in_the_config() {
+  # Arg: "rag.enabled" or "distill.enabled"
+  local key="${1:-}"
+  case "$key" in
+    rag.enabled)     _doctor_write_config false true ;;
+    distill.enabled) _doctor_write_config true  false ;;
+    *) return 1 ;;
+  esac
+}
+
+given_a_snapshot_of_the_scratch_vault_and_obsidian_memory_config_is_taken() {
+  D_SNAPSHOT="$(_doctor_tree_digest)"
+}
+
+# ------------------------------------------------------------
+# When steps
+# ------------------------------------------------------------
+
+when_i_run() {
+  local cmd="${1:-}"
+  case "$cmd" in
+    "/obsidian-memory:doctor")        _doctor_run "" ;;
+    "/obsidian-memory:doctor --json") _doctor_run "--json" ;;
+    *) return 1 ;;
+  esac
+}
+
+when_i_run_in_the_healthy_state() {
+  when_i_run "$1"
+}
+
+# ------------------------------------------------------------
+# Then steps
+# ------------------------------------------------------------
+
+then_the_doctor_output_contains() {
+  local needle="${1:-}"
+  printf '%s' "$D_STDOUT" | grep -qF -- "$needle"
+}
+
+then_the_doctor_output_does_not_contain() {
+  local needle="${1:-}"
+  ! printf '%s' "$D_STDOUT" | grep -qF -- "$needle"
+}
+
+then_the_doctor_exit_code_is_0() {
+  [ "$D_RC" -eq 0 ]
+}
+
+then_the_doctor_exit_code_is_non_zero() {
+  [ "$D_RC" -ne 0 ]
+}
+
+then_the_doctor_output_is_a_single_valid_json_object() {
+  printf '%s' "$D_STDOUT" | jq empty
+}
+
+then_the_json_object_has_top_level_equal_to_true() {
+  # Arg: "ok"
+  local key="${1:-ok}"
+  [ "$(printf '%s' "$D_STDOUT" | jq -r --arg k "$key" '.[$k]')" = "true" ]
+}
+
+then_the_json_object_has_top_level_equal_to_false() {
+  local key="${1:-ok}"
+  [ "$(printf '%s' "$D_STDOUT" | jq -r --arg k "$key" '.[$k]')" = "false" ]
+}
+
+then_the_json_object_has_check_with_status() {
+  # Args: "config", "ok"
+  local check="$1" status="$2"
+  [ "$(printf '%s' "$D_STDOUT" | jq -r --arg c "$check" '.checks[$c].status')" = "$status" ]
+}
+
+then_the_json_object_has_check_with_hint_containing() {
+  # Args: "vault_path", "/obsidian-memory:setup"
+  local check="$1" needle="$2"
+  printf '%s' "$D_STDOUT" | jq -r --arg c "$check" '.checks[$c].hint' | grep -qF -- "$needle"
+}
+
+then_the_scratch_vault_snapshot_is_unchanged() {
+  local current
+  current="$(_doctor_tree_digest)"
+  [ "$current" = "$D_SNAPSHOT" ]
+}

--- a/tests/integration/doctor.bats
+++ b/tests/integration/doctor.bats
@@ -223,6 +223,8 @@ EOF
   [ "$(printf '%s' "$output" | jq -r '.checks.projects_symlink.status')" = "ok" ]
   [ "$(printf '%s' "$output" | jq -r '.checks.rag_enabled.status')" = "ok" ]
   [ "$(printf '%s' "$output" | jq -r '.checks.distill_enabled.status')" = "ok" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.ripgrep.status')" = "info" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.mcp.status')" = "info" ]
 }
 
 @test "--json emits ok=false with per-check hint on broken install" {

--- a/tests/integration/doctor.bats
+++ b/tests/integration/doctor.bats
@@ -1,0 +1,278 @@
+#!/usr/bin/env bats
+
+# tests/integration/doctor.bats — end-to-end coverage of vault-doctor.sh.
+#
+# Every scenario runs under the bats scratch harness (tests/helpers/scratch)
+# so $HOME is redirected to $BATS_TEST_TMPDIR/home and $VAULT is a disposable
+# scratch vault. teardown() asserts the real $HOME is byte-identical to its
+# pre-test snapshot — proving the read-only invariant.
+
+setup() {
+  load '../helpers/scratch'
+
+  DOCTOR="$PLUGIN_ROOT/scripts/vault-doctor.sh"
+  export DOCTOR
+
+  CONFIG="$HOME/.claude/obsidian-memory/config.json"
+  export CONFIG
+  mkdir -p "$HOME/.claude/obsidian-memory" "$HOME/.claude/projects"
+
+  _install_safe_path
+}
+
+teardown() {
+  assert_home_untouched
+}
+
+# Install a fresh PATH containing symlinks to every real executable, plus a
+# stub "claude" we fully control. Individual tests delete symlinks from this
+# dir to simulate a missing binary.
+_install_safe_path() {
+  local bindir="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$bindir"
+
+  local d f name
+  local IFS_SAVED="$IFS"
+  IFS=':'
+  for d in $PATH; do
+    [ -d "$d" ] || continue
+    for f in "$d"/*; do
+      [ -x "$f" ] || continue
+      name="$(basename "$f")"
+      [ -e "$bindir/$name" ] && continue
+      ln -s "$f" "$bindir/$name" 2>/dev/null || true
+    done
+  done
+  IFS="$IFS_SAVED"
+
+  # Stub `claude` — real binary's mcp list may hit a live daemon.
+  rm -f "$bindir/claude"
+  cat > "$bindir/claude" <<'CLAUDE'
+#!/usr/bin/env bash
+if [ "${1:-}" = "mcp" ] && [ "${2:-}" = "list" ]; then
+  echo "obsidian: ws://localhost:22360"
+  exit 0
+fi
+exit 0
+CLAUDE
+  chmod +x "$bindir/claude"
+
+  PATH="$bindir"
+  export PATH
+}
+
+_hide() {
+  rm -f "$BATS_TEST_TMPDIR/bin/$1"
+}
+
+_healthy_install() {
+  cat > "$CONFIG" <<EOF
+{"vaultPath":"$VAULT","rag":{"enabled":true},"distill":{"enabled":true}}
+EOF
+  mkdir -p "$VAULT/claude-memory/sessions"
+  ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+}
+
+# --- Happy path -------------------------------------------------------------
+
+@test "healthy install: all probes report OK/INFO and exit 0" {
+  _healthy_install
+
+  run "$DOCTOR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"All checks passed."* ]]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+# --- Failure modes F1–F9 ----------------------------------------------------
+
+@test "F1: config missing reports FAIL with setup hint" {
+  run "$DOCTOR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"config"* ]]
+  [[ "$output" == *"/obsidian-memory:setup"* ]]
+}
+
+@test "F2: vaultPath missing from config reports FAIL with setup hint" {
+  echo '{"rag":{"enabled":true},"distill":{"enabled":true}}' > "$CONFIG"
+  mkdir -p "$VAULT/claude-memory/sessions"
+  ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+
+  run "$DOCTOR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"vaultPath"* ]]
+  [[ "$output" == *"/obsidian-memory:setup"* ]]
+}
+
+@test "F3: vaultPath points at non-existent directory reports FAIL with setup hint" {
+  cat > "$CONFIG" <<EOF
+{"vaultPath":"$BATS_TEST_TMPDIR/nope","rag":{"enabled":true},"distill":{"enabled":true}}
+EOF
+
+  run "$DOCTOR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"does not exist"* ]]
+  [[ "$output" == *"/obsidian-memory:setup"* ]]
+}
+
+@test "F4: jq missing reports FAIL with brew hint" {
+  _healthy_install
+  _hide jq
+
+  run "$DOCTOR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"jq"* ]]
+  [[ "$output" == *"brew install jq"* ]]
+}
+
+@test "F5: claude missing reports FAIL with CLI install hint" {
+  _healthy_install
+  _hide claude
+
+  run "$DOCTOR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"claude"* ]]
+  [[ "$output" == *"Claude Code CLI"* ]]
+}
+
+@test "F6: projects symlink broken reports FAIL with setup hint" {
+  _healthy_install
+  rm -f "$VAULT/claude-memory/projects"
+  ln -s "$BATS_TEST_TMPDIR/does-not-exist" "$VAULT/claude-memory/projects"
+
+  run "$DOCTOR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"projects"* ]]
+  [[ "$output" == *"/obsidian-memory:setup"* ]]
+}
+
+@test "F7: sessions directory missing reports FAIL with setup hint" {
+  cat > "$CONFIG" <<EOF
+{"vaultPath":"$VAULT","rag":{"enabled":true},"distill":{"enabled":true}}
+EOF
+  mkdir -p "$VAULT/claude-memory"
+  ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+
+  run "$DOCTOR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"sessions"* ]]
+  [[ "$output" == *"/obsidian-memory:setup"* ]]
+}
+
+@test "F8: rag.enabled=false reports FAIL with toggle hint" {
+  cat > "$CONFIG" <<EOF
+{"vaultPath":"$VAULT","rag":{"enabled":false},"distill":{"enabled":true}}
+EOF
+  mkdir -p "$VAULT/claude-memory/sessions"
+  ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+
+  run "$DOCTOR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"rag.enabled"* ]]
+  [[ "$output" == *"/obsidian-memory:toggle rag on"* ]]
+}
+
+@test "F9: distill.enabled=false reports FAIL with toggle hint" {
+  cat > "$CONFIG" <<EOF
+{"vaultPath":"$VAULT","rag":{"enabled":true},"distill":{"enabled":false}}
+EOF
+  mkdir -p "$VAULT/claude-memory/sessions"
+  ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+
+  run "$DOCTOR"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"FAIL"* ]]
+  [[ "$output" == *"distill.enabled"* ]]
+  [[ "$output" == *"/obsidian-memory:toggle distill on"* ]]
+}
+
+# --- Optional deps ----------------------------------------------------------
+
+@test "ripgrep missing is INFO, not FAIL, and does not fail the run" {
+  _healthy_install
+  _hide rg
+
+  run "$DOCTOR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"INFO"* ]]
+  [[ "$output" == *"ripgrep"* ]]
+}
+
+# --- JSON output ------------------------------------------------------------
+
+@test "--json emits valid JSON with ok=true on healthy install" {
+  _healthy_install
+
+  run "$DOCTOR" --json
+  [ "$status" -eq 0 ]
+  printf '%s' "$output" | jq empty
+  [ "$(printf '%s' "$output" | jq -r .ok)" = "true" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.config.status')" = "ok" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.vault_path.status')" = "ok" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.jq.status')" = "ok" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.claude.status')" = "ok" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.sessions_dir.status')" = "ok" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.projects_symlink.status')" = "ok" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.rag_enabled.status')" = "ok" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.distill_enabled.status')" = "ok" ]
+}
+
+@test "--json emits ok=false with per-check hint on broken install" {
+  cat > "$CONFIG" <<EOF
+{"vaultPath":"$BATS_TEST_TMPDIR/nope","rag":{"enabled":true},"distill":{"enabled":true}}
+EOF
+
+  run "$DOCTOR" --json
+  [ "$status" -ne 0 ]
+  printf '%s' "$output" | jq empty
+  [ "$(printf '%s' "$output" | jq -r .ok)" = "false" ]
+  [ "$(printf '%s' "$output" | jq -r '.checks.vault_path.status')" = "fail" ]
+  printf '%s' "$output" | jq -r '.checks.vault_path.hint' | grep -q '/obsidian-memory:setup'
+}
+
+# --- Read-only invariant ----------------------------------------------------
+
+@test "doctor is read-only: scratch vault tree unchanged across healthy + broken invocations" {
+  _healthy_install
+
+  local before after
+  before="$(find "$VAULT" "$HOME/.claude/obsidian-memory" -print0 2>/dev/null | LC_ALL=C sort -z | xargs -0 cksum 2>/dev/null | LC_ALL=C sort)"
+
+  run "$DOCTOR"
+  [ "$status" -eq 0 ]
+  run "$DOCTOR" --json
+  [ "$status" -eq 0 ]
+
+  rm -rf "$VAULT/claude-memory/sessions"
+  run "$DOCTOR"
+  [ "$status" -ne 0 ]
+
+  mkdir -p "$VAULT/claude-memory/sessions"
+  run "$DOCTOR"
+  [ "$status" -eq 0 ]
+
+  after="$(find "$VAULT" "$HOME/.claude/obsidian-memory" -print0 2>/dev/null | LC_ALL=C sort -z | xargs -0 cksum 2>/dev/null | LC_ALL=C sort)"
+  [ "$before" = "$after" ]
+}
+
+# --- CLI contract -----------------------------------------------------------
+
+@test "unknown argument exits 2 with usage on stderr" {
+  run "$DOCTOR" --nope
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage:"* || "$output" == *"usage:"* ]]
+}
+
+@test "--help exits 0 with usage" {
+  run "$DOCTOR" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* || "$output" == *"usage:"* ]]
+}

--- a/tests/run-bdd.sh
+++ b/tests/run-bdd.sh
@@ -36,6 +36,7 @@ _step_file_for() {
     feature-rag-prompt-injection)                     printf '%s' "$STEPS_DIR/rag.sh" ;;
     feature-session-distillation-hook)                printf '%s' "$STEPS_DIR/distill.sh" ;;
     feature-manual-distill-skill)                     printf '%s' "$STEPS_DIR/manual-distill.sh" ;;
+    feature-doctor-health-check-skill)                printf '%s' "$STEPS_DIR/doctor.sh" ;;
     feature-set-up-bats-core-cucumber-shell-test-harness) printf '%s' "$STEPS_DIR/harness.sh" ;;
     example)                                          printf '%s' "$STEPS_DIR/example.sh" ;;
     *)


### PR DESCRIPTION
## Summary

Implements the `/obsidian-memory:doctor` health-check skill from issue #2. The skill surfaces silent install failures on demand without mutating any state — diagnosing problems the hooks intentionally hide behind `exit 0`.

Closes #2

## What changed

- **`skills/doctor/SKILL.md`** — new skill: `/obsidian-memory:doctor` with optional `--json` flag
- **`scripts/vault-doctor.sh`** — read-only probe script covering all AC2 failure modes (config, vault path, `jq`/`claude`/`ripgrep`, symlink, sessions dir, `rag.enabled`/`distill.enabled`)
- **`tests/integration/doctor.bats`** — bats integration tests for happy path + each failure mode
- **`specs/feature-doctor-health-check-skill/`** — requirements, design, tasks, and Gherkin scenarios
- **`CHANGELOG.md`** — `[0.2.0]` entry; `[0.1.0]` formally recorded
- **`.claude-plugin/plugin.json`** — version bumped `0.1.0 → 0.2.0`

## Spec

- Requirements: [`specs/feature-doctor-health-check-skill/requirements.md`](specs/feature-doctor-health-check-skill/requirements.md)
- Design: [`specs/feature-doctor-health-check-skill/design.md`](specs/feature-doctor-health-check-skill/design.md)
- Tasks: [`specs/feature-doctor-health-check-skill/tasks.md`](specs/feature-doctor-health-check-skill/tasks.md)

## Acceptance criteria

- [x] AC1: Doctor passes (exit 0) on a healthy install with per-check `OK` lines and `All checks passed.` summary
- [x] AC2: Doctor reports each failure mode (F1–F9) with `FAIL: <reason> — <hint>` and exits non-zero
- [x] AC3: Doctor is read-only — no files written, no symlinks changed under any test state
- [x] AC4: Optional dependencies (`ripgrep`, MCP) surface as informational, not failing
- [x] Tests run against scratch `$HOME` and scratch vault, never the operator's real install

## Version bump

`0.1.0 → 0.2.0` (minor — `enhancement` label)

## Test plan

- [ ] Run `bats tests/integration/doctor.bats` — all scenarios pass
- [ ] Run `/obsidian-memory:doctor` against a real healthy install — all `OK`, exit 0
- [ ] Run `/obsidian-memory:doctor` with `jq` temporarily removed from PATH — `FAIL` reported with brew hint
- [ ] Run `/obsidian-memory:doctor --json` — valid JSON output with `ok: true`