### PR TITLE
feat: add /obsidian-memory:teardown skill (inverse of setup) (#3)

### DIFF
--- a/scripts/vault-teardown.sh
+++ b/scripts/vault-teardown.sh
@@ -212,13 +212,19 @@ demote_sessions_to_preserve() {
   local sessions="$VAULT/claude-memory/sessions"
   local index="$VAULT/claude-memory/Index.md"
   local new=() entry
-  for entry in "${PLAN_REMOVE[@]}"; do
-    case "$entry" in
-      sessions:*|index:*) : ;;
-      *) new+=("$entry") ;;
-    esac
-  done
-  PLAN_REMOVE=("${new[@]}")
+  if [ "${#PLAN_REMOVE[@]}" -gt 0 ]; then
+    for entry in "${PLAN_REMOVE[@]}"; do
+      case "$entry" in
+        sessions:*|index:*) : ;;
+        *) new+=("$entry") ;;
+      esac
+    done
+  fi
+  if [ "${#new[@]}" -gt 0 ]; then
+    PLAN_REMOVE=("${new[@]}")
+  else
+    PLAN_REMOVE=()
+  fi
   if [ -d "$sessions" ]; then
     PLAN_PRESERVE+=("sessions:$sessions")
   fi
@@ -264,12 +270,16 @@ print_plan_section() {
 
   printf 'PLAN\n'
   local entry
-  for entry in "${PLAN_REMOVE[@]}"; do
-    _format_line "$remove_label" "$remove_color" "$entry"
-  done
-  for entry in "${PLAN_PRESERVE[@]}"; do
-    _format_line "$preserve_label" "$preserve_color" "$entry"
-  done
+  if [ "${#PLAN_REMOVE[@]}" -gt 0 ]; then
+    for entry in "${PLAN_REMOVE[@]}"; do
+      _format_line "$remove_label" "$remove_color" "$entry"
+    done
+  fi
+  if [ "${#PLAN_PRESERVE[@]}" -gt 0 ]; then
+    for entry in "${PLAN_PRESERVE[@]}"; do
+      _format_line "$preserve_label" "$preserve_color" "$entry"
+    done
+  fi
   printf '\n'
 }
 
@@ -423,16 +433,9 @@ main() {
     fi
   fi
 
-  # Fixed action order (see design → Data Flow step 8):
-  #   a. unlink projects symlink
-  #   b. (if --purge confirmed) remove sessions + Index.md
-  #   c. remove config file + cleanup empty parents
-  #   d. (if --unregister-mcp) best-effort claude mcp remove
   act_default
   if [ "$purged" -eq 1 ]; then
     act_purge
-  elif [ "$PURGE" -eq 1 ]; then
-    act_preserve_sessions_and_index
   else
     act_preserve_sessions_and_index
   fi

--- a/scripts/vault-teardown.sh
+++ b/scripts/vault-teardown.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+# vault-teardown.sh — inverse of /obsidian-memory:setup.
+#
+# Removes the obsidian-memory install footprint:
+#   - ~/.claude/obsidian-memory/config.json
+#   - <vault>/claude-memory/projects  (symlink only, never a real directory)
+# Optionally:
+#   --purge           additionally deletes <vault>/claude-memory/sessions/
+#                     and <vault>/claude-memory/Index.md after a typed "yes"
+#                     confirmation (exact literal, case-sensitive)
+#   --unregister-mcp  best-effort `claude mcp remove obsidian -s user`
+#   --dry-run         prints the plan; touches nothing; never prompts
+#
+# Exit codes:
+#   0  success (including idempotent no-op and cancelled purge)
+#   1  path-safety refusal — layout does not match setup's footprint
+#   2  bad usage (unknown flag)
+
+set -u
+
+# shellcheck disable=SC2329  # invoked indirectly by the ERR trap
+log_err() { printf '[%s] %s\n' "$(basename "$0")" "$*" >&2; }
+trap 'log_err "failed at line $LINENO"; exit 1' ERR
+
+CONFIG="${HOME}/.claude/obsidian-memory/config.json"
+EXPECTED_PROJECTS_TARGET="${HOME}/.claude/projects"
+
+# --- ANSI color (TTY only) --------------------------------------------------
+
+if [ -t 1 ]; then
+  C_RESET=$'\033[0m'
+  C_GREEN=$'\033[32m'
+  C_RED=$'\033[31m'
+  C_YELLOW=$'\033[33m'
+  C_BOLD=$'\033[1m'
+else
+  C_RESET=""
+  C_GREEN=""
+  C_RED=""
+  C_YELLOW=""
+  C_BOLD=""
+fi
+
+# --- CLI --------------------------------------------------------------------
+
+PURGE=0
+UNREGISTER_MCP=0
+DRY_RUN=0
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: vault-teardown.sh [--purge] [--unregister-mcp] [--dry-run]
+
+  --purge           Additionally delete distilled sessions and Index.md.
+                    Requires typing the literal string 'yes' at the prompt.
+  --unregister-mcp  Best-effort unregister the Obsidian MCP server.
+  --dry-run         Print the plan and exit 0 without touching anything.
+
+Reverses the footprint written by /obsidian-memory:setup. Exits 0 on success
+(including the idempotent no-op and cancelled purge); exits 1 on a path-safety
+refusal; exits 2 on bad usage.
+USAGE
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --purge)          PURGE=1 ;;
+      --unregister-mcp) UNREGISTER_MCP=1 ;;
+      --dry-run)        DRY_RUN=1 ;;
+      -h|--help)        usage; exit 0 ;;
+      *)                usage; exit 2 ;;
+    esac
+    shift
+  done
+}
+
+# --- Output helpers ---------------------------------------------------------
+
+print_header() {
+  printf '%sobsidian-memory teardown%s\n' "$C_BOLD" "$C_RESET"
+  printf '%s\n' "────────────────────────"
+}
+
+print_vault_line() {
+  printf 'vault: %s\n\n' "$1"
+}
+
+# --- Refusal (Stage 2 failure) ---------------------------------------------
+
+refuse() {
+  # $1 = vault path (may be "(unknown)"), $2 = mismatch description
+  local vault="$1" reason="$2"
+  print_header
+  print_vault_line "$vault"
+  printf '%sREFUSED%s\n' "${C_BOLD}${C_RED}" "$C_RESET"
+  printf '  %s\n' "$reason"
+  printf '  This does not look like an obsidian-memory install — refusing to delete anything.\n'
+  printf '  Run /obsidian-memory:doctor to diagnose the config, then reconcile manually.\n'
+  exit 1
+}
+
+# --- Stage 1: discover ------------------------------------------------------
+
+VAULT=""
+
+discover() {
+  if [ ! -f "$CONFIG" ]; then
+    print_header
+    printf 'No obsidian-memory config found at %s — nothing to do.\n' "$CONFIG"
+    exit 0
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    refuse "(unknown)" \
+      "jq is not on PATH; cannot read vaultPath from $CONFIG — install jq and retry."
+  fi
+
+  local raw
+  raw="$(jq -r '.vaultPath // ""' "$CONFIG" 2>/dev/null || printf '')"
+  if [ -z "$raw" ] || [ "$raw" = "null" ]; then
+    refuse "(unknown)" \
+      "vaultPath is missing or empty in $CONFIG."
+  fi
+  VAULT="$raw"
+}
+
+# --- Stage 2: validate (path-safety gate) ----------------------------------
+
+validate() {
+  if [ ! -d "$VAULT" ]; then
+    refuse "$VAULT" "$VAULT does not exist or is not a directory."
+  fi
+
+  local cm="$VAULT/claude-memory"
+  if [ ! -d "$cm" ]; then
+    refuse "$VAULT" "$VAULT does not contain a claude-memory/ directory."
+  fi
+
+  local projects="$cm/projects"
+  # Projects entry must be either absent OR a symlink that resolves to the
+  # expected target via plain readlink (no -f — BSD readlink lacks it).
+  if [ -e "$projects" ] || [ -L "$projects" ]; then
+    if [ ! -L "$projects" ]; then
+      refuse "$VAULT" \
+        "$projects exists but is not a symlink created by setup."
+    fi
+    local target
+    target="$(readlink "$projects" 2>/dev/null || printf '')"
+    if [ "$target" != "$EXPECTED_PROJECTS_TARGET" ]; then
+      refuse "$VAULT" \
+        "$projects points at $target (expected $EXPECTED_PROJECTS_TARGET)."
+    fi
+  fi
+}
+
+# --- Stage 3: plan ----------------------------------------------------------
+
+# Parallel arrays keyed by index; each entry is "kind:path-or-note".
+PLAN_REMOVE=()
+PLAN_PRESERVE=()
+SESSIONS_COUNT=0
+
+count_sessions() {
+  local sessions="$VAULT/claude-memory/sessions"
+  if [ -d "$sessions" ]; then
+    SESSIONS_COUNT="$(
+      find "$sessions" -type f -name '*.md' 2>/dev/null | wc -l | tr -d '[:space:]'
+    )"
+    [ -n "$SESSIONS_COUNT" ] || SESSIONS_COUNT=0
+  else
+    SESSIONS_COUNT=0
+  fi
+}
+
+compose_plan() {
+  count_sessions
+  local cm="$VAULT/claude-memory"
+  local projects="$cm/projects"
+  local sessions="$cm/sessions"
+  local index="$cm/Index.md"
+
+  PLAN_REMOVE+=("config:$CONFIG")
+  if [ -L "$projects" ]; then
+    PLAN_REMOVE+=("symlink:$projects")
+  fi
+
+  if [ "$PURGE" -eq 1 ]; then
+    if [ -d "$sessions" ]; then
+      PLAN_REMOVE+=("sessions:$sessions")
+    fi
+    if [ -f "$index" ]; then
+      PLAN_REMOVE+=("index:$index")
+    fi
+  else
+    if [ -d "$sessions" ]; then
+      PLAN_PRESERVE+=("sessions:$sessions")
+    fi
+    if [ -f "$index" ]; then
+      PLAN_PRESERVE+=("index:$index")
+    fi
+  fi
+
+  if [ "$UNREGISTER_MCP" -eq 1 ]; then
+    PLAN_REMOVE+=("mcp:obsidian MCP server registration")
+  fi
+}
+
+# Move sessions + Index.md entries from PLAN_REMOVE back into PLAN_PRESERVE
+# after a cancelled purge.
+demote_sessions_to_preserve() {
+  local sessions="$VAULT/claude-memory/sessions"
+  local index="$VAULT/claude-memory/Index.md"
+  local new=() entry
+  for entry in "${PLAN_REMOVE[@]}"; do
+    case "$entry" in
+      sessions:*|index:*) : ;;
+      *) new+=("$entry") ;;
+    esac
+  done
+  PLAN_REMOVE=("${new[@]}")
+  if [ -d "$sessions" ]; then
+    PLAN_PRESERVE+=("sessions:$sessions")
+  fi
+  if [ -f "$index" ]; then
+    PLAN_PRESERVE+=("index:$index")
+  fi
+}
+
+# --- Plan rendering ---------------------------------------------------------
+
+_format_line() {
+  # $1 = label (REMOVE / PRESERVE / WOULD REMOVE / WOULD PRESERVE / REMOVED / PRESERVED)
+  # $2 = color, $3 = entry ("kind:value")
+  local label="$1" color="$2" entry="$3"
+  local kind="${entry%%:*}" value="${entry#*:}"
+  local annotation=""
+  case "$kind" in
+    symlink)  annotation=" (symlink)" ;;
+    sessions) annotation="  (${SESSIONS_COUNT} notes)" ;;
+    mcp)      : ;;
+    *)        : ;;
+  esac
+  printf '  %s%-10s%s %s%s\n' "$color" "$label" "$C_RESET" "$value" "$annotation"
+}
+
+print_plan_section() {
+  local mode="$1"
+  local remove_label preserve_label remove_color preserve_color
+  case "$mode" in
+    dry_run)
+      remove_label="WOULD REMOVE"
+      preserve_label="WOULD PRESERVE"
+      remove_color="$C_YELLOW"
+      preserve_color="$C_YELLOW"
+      ;;
+    *)
+      remove_label="REMOVE"
+      preserve_label="PRESERVE"
+      remove_color="$C_RED"
+      preserve_color="$C_GREEN"
+      ;;
+  esac
+
+  printf 'PLAN\n'
+  local entry
+  for entry in "${PLAN_REMOVE[@]}"; do
+    _format_line "$remove_label" "$remove_color" "$entry"
+  done
+  for entry in "${PLAN_PRESERVE[@]}"; do
+    _format_line "$preserve_label" "$preserve_color" "$entry"
+  done
+  printf '\n'
+}
+
+# --- Stage 3b: purge confirmation -------------------------------------------
+
+# Returns 0 if the user typed literal "yes", 1 otherwise. Reads exactly one
+# line from stdin. EOF or any other response (including "y", "YES", empty)
+# is treated as refusal.
+confirm_purge() {
+  local sessions="$VAULT/claude-memory/sessions"
+  printf 'About to delete %s distilled note file(s) under %s.\n' \
+    "$SESSIONS_COUNT" "$sessions" >&2
+  printf "Type 'yes' to confirm (anything else cancels): " >&2
+  local reply=""
+  if ! IFS= read -r reply; then
+    printf '\n' >&2
+    return 1
+  fi
+  [ "$reply" = "yes" ]
+}
+
+# --- Stage 4: act -----------------------------------------------------------
+
+ACTIONS_DONE=()
+
+_record_action() {
+  # $1 = label (REMOVED / PRESERVED), $2 = entry
+  ACTIONS_DONE+=("$1|$2")
+}
+
+act_default() {
+  local projects="$VAULT/claude-memory/projects"
+  if [ -L "$projects" ]; then
+    unlink "$projects"
+    _record_action "REMOVED" "symlink:$projects"
+  fi
+}
+
+act_purge() {
+  local sessions="$VAULT/claude-memory/sessions"
+  local index="$VAULT/claude-memory/Index.md"
+  if [ -d "$sessions" ]; then
+    rm -rf "$sessions"
+    _record_action "REMOVED" "sessions:$sessions"
+  fi
+  if [ -f "$index" ]; then
+    rm -f "$index"
+    _record_action "REMOVED" "index:$index"
+  fi
+}
+
+act_preserve_sessions_and_index() {
+  local sessions="$VAULT/claude-memory/sessions"
+  local index="$VAULT/claude-memory/Index.md"
+  if [ -d "$sessions" ]; then
+    _record_action "PRESERVED" "sessions:$sessions"
+  fi
+  if [ -f "$index" ]; then
+    _record_action "PRESERVED" "index:$index"
+  fi
+}
+
+act_config() {
+  rm -f "$CONFIG"
+  _record_action "REMOVED" "config:$CONFIG"
+  # Best-effort parent cleanup — only succeeds when empty.
+  rmdir "$(dirname "$CONFIG")" 2>/dev/null || true
+  # Best-effort claude-memory/ cleanup when purge emptied it.
+  rmdir "$VAULT/claude-memory" 2>/dev/null || true
+}
+
+# --- Stage 5: --unregister-mcp ---------------------------------------------
+
+act_unregister_mcp() {
+  if ! command -v claude >/dev/null 2>&1; then
+    printf 'MCP: claude not on PATH — skipping unregistration (non-fatal).\n'
+    return 0
+  fi
+
+  local rc=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 3 claude mcp remove obsidian -s user >/dev/null 2>&1 || rc=$?
+  else
+    claude mcp remove obsidian -s user >/dev/null 2>&1 || rc=$?
+  fi
+
+  if [ "$rc" -eq 0 ]; then
+    printf 'MCP: obsidian server unregistered.\n'
+  elif [ "$rc" -eq 124 ]; then
+    printf 'MCP: claude mcp remove timed out — skipping (non-fatal).\n'
+  else
+    printf 'MCP: claude mcp remove exited %s — skipping (non-fatal).\n' "$rc"
+  fi
+}
+
+# --- Action rendering -------------------------------------------------------
+
+print_actions_section() {
+  [ "${#ACTIONS_DONE[@]}" -gt 0 ] || return 0
+  printf 'ACTIONS\n'
+  local row label entry kind value annotation color
+  for row in "${ACTIONS_DONE[@]}"; do
+    label="${row%%|*}"
+    entry="${row#*|}"
+    kind="${entry%%:*}"
+    value="${entry#*:}"
+    annotation=""
+    case "$kind" in
+      symlink)  annotation="" ;;
+      sessions) annotation="  (${SESSIONS_COUNT} notes)" ;;
+      *)        annotation="" ;;
+    esac
+    case "$label" in
+      REMOVED)   color="$C_RED" ;;
+      PRESERVED) color="$C_GREEN" ;;
+      *)         color="" ;;
+    esac
+    printf '  %s%-10s%s %s%s\n' "$color" "$label" "$C_RESET" "$value" "$annotation"
+  done
+  printf '\n'
+}
+
+# --- Main -------------------------------------------------------------------
+
+main() {
+  parse_args "$@"
+
+  discover
+  validate
+
+  compose_plan
+
+  print_header
+  print_vault_line "$VAULT"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    print_plan_section "dry_run"
+    printf 'Dry-run — no filesystem changes made.\n'
+    exit 0
+  fi
+
+  print_plan_section "normal"
+
+  local purged=0
+  if [ "$PURGE" -eq 1 ]; then
+    if confirm_purge; then
+      purged=1
+    else
+      printf '\nSessions preserved — purge cancelled.\n\n'
+      demote_sessions_to_preserve
+    fi
+  fi
+
+  # Fixed action order (see design → Data Flow step 8):
+  #   a. unlink projects symlink
+  #   b. (if --purge confirmed) remove sessions + Index.md
+  #   c. remove config file + cleanup empty parents
+  #   d. (if --unregister-mcp) best-effort claude mcp remove
+  act_default
+  if [ "$purged" -eq 1 ]; then
+    act_purge
+  elif [ "$PURGE" -eq 1 ]; then
+    act_preserve_sessions_and_index
+  else
+    act_preserve_sessions_and_index
+  fi
+  act_config
+
+  if [ "$UNREGISTER_MCP" -eq 1 ]; then
+    act_unregister_mcp
+  fi
+
+  print_actions_section
+
+  if [ "$purged" -eq 1 ]; then
+    printf 'Teardown complete. Distilled notes deleted.\n'
+  else
+    printf 'Teardown complete. Distilled notes preserved.\n'
+  fi
+  exit 0
+}
+
+main "$@"

--- a/skills/teardown/SKILL.md
+++ b/skills/teardown/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: teardown
+description: Inverse of /obsidian-memory:setup — safely removes the config file and projects symlink, optionally purges distilled session notes behind a typed-"yes" prompt, and optionally unregisters the Obsidian MCP server. Use when the user says "uninstall obsidian memory", "remove obsidian-memory", "tear down obsidian memory", "undo obsidian-memory setup", "reverse obsidian-memory setup", "clean up obsidian-memory", "inverse of setup", or invokes /obsidian-memory:teardown.
+allowed-tools: Bash, Read
+model: sonnet
+effort: low
+---
+
+# obsidian-memory: teardown
+
+Cleanly reverse the filesystem footprint written by `/obsidian-memory:setup`. Teardown is a **thin relayer**: every check and every deletion lives in `scripts/vault-teardown.sh`, which Claude invokes once and reports back verbatim. The script's default behavior is the safe behavior — it removes the plugin's own config and the `<vault>/claude-memory/projects` symlink, and it **preserves distilled session notes** unless the user explicitly asks for them to be purged and confirms at a typed-`yes` prompt.
+
+## When to Use
+
+- The user wants to uninstall the plugin's footprint (e.g., before switching vaults, before filing a reproducible bug, or before removing the plugin entirely with `claude plugin uninstall`).
+- The user wants to reverse what `/obsidian-memory:setup` wrote without hand-tracing every path.
+- The user is migrating to a new vault and wants the old vault's `claude-memory/` symlink and the stale `config.json` gone.
+- The user wants to unregister the Obsidian MCP server as part of a cleanup (`--unregister-mcp`).
+- The user wants to preview what would be removed before acting (`--dry-run`).
+
+## When NOT to Use
+
+- **To uninstall the plugin itself.** Teardown removes *setup's footprint*, not the plugin package. Uninstalling the plugin is `claude plugin uninstall obsidian-memory` and is outside this skill's scope.
+- **To migrate distilled notes to a new vault.** Teardown deletes or preserves; it does not copy. If the user wants to keep the notes, they should either run default teardown (which preserves them in place) and manually move `<vault>/claude-memory/sessions/` / `Index.md` to the new vault, or set up against the new vault first and then run teardown against the old one.
+- **To delete the vault itself.** Teardown only touches `<vault>/claude-memory/` and `~/.claude/obsidian-memory/`. The vault directory is user-owned and never removed.
+- **To recover from a bad config without understanding why.** If `/obsidian-memory:doctor` reports failures, run doctor first and read the diagnosis — teardown's refusal path deliberately points the user there rather than guessing.
+
+## Invocation
+
+```
+/obsidian-memory:teardown                       # default: remove config + symlink; preserve sessions + Index.md
+/obsidian-memory:teardown --purge               # also delete sessions/ and Index.md after typed "yes"
+/obsidian-memory:teardown --unregister-mcp      # also best-effort `claude mcp remove obsidian -s user`
+/obsidian-memory:teardown --dry-run             # print the plan; touch nothing; never prompt
+/obsidian-memory:teardown --purge --dry-run     # plan includes sessions under WOULD REMOVE; still no prompt
+```
+
+Flags combine freely. `--dry-run` suppresses every side effect, including the MCP command.
+
+## Behavior
+
+1. Invoke `"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/obsidian-memory}/scripts/vault-teardown.sh"` with any arguments the user passed, using `"$@"` so every flag passes through verbatim.
+2. Relay the script's stdout and exit code directly — do not re-interpret the results, do not attempt to fix the refusal, and **never call the script twice in one invocation**. A second call after a successful run would hit the idempotent "nothing to do" path; a second call after a refusal would still refuse.
+3. If the exit code is non-zero, call out the specific reason in a short summary (for example, "teardown refused: projects symlink points at an unrelated path — run `/obsidian-memory:doctor` to diagnose") so the user does not have to re-read the full report.
+
+## Flag Reference
+
+| Flag | Effect |
+|------|--------|
+| *(none)* | Remove `~/.claude/obsidian-memory/config.json` and the `<vault>/claude-memory/projects` symlink. Preserve `sessions/` and `Index.md`. Leave the MCP registration alone. |
+| `--purge` | On top of the default removals, delete `<vault>/claude-memory/sessions/` and `<vault>/claude-memory/Index.md` **after the user types the literal string `yes`** at the confirmation prompt. Any other response cancels the purge. |
+| `--unregister-mcp` | On top of the default removals, best-effort run `timeout 3 claude mcp remove obsidian -s user`. A non-zero exit, a timeout, or a missing `claude` binary is reported as a one-line non-fatal warning — teardown still exits 0. |
+| `--dry-run` | Print the plan with `WOULD REMOVE:` / `WOULD PRESERVE:` labels and exit 0 without touching anything. Combines with every other flag: `--dry-run --purge` lists `sessions/` and `Index.md` under WOULD REMOVE without prompting; `--dry-run --unregister-mcp` does **not** invoke `claude mcp remove`. |
+| *any unknown flag* | Print a usage line to stderr and exit 2. |
+
+## Safety Guarantees
+
+These are the load-bearing invariants teardown enforces. Both the skill and the underlying script exist to preserve them.
+
+### Distilled notes are the user's memory
+
+The default run **never deletes** `<vault>/claude-memory/sessions/` or `<vault>/claude-memory/Index.md`. Purging requires both `--purge` *and* the user typing the exact literal string `yes` at the confirmation prompt. The prompt is case-sensitive: `y`, `Y`, `YES`, an empty line, or EOF on stdin all cancel the purge and preserve the notes. There is deliberately **no `-y` / `--yes` override** — anyone who genuinely needs unattended purge can delete the plain-Markdown note files directly.
+
+`--purge` is destructive and not reversible. Distilled notes are ordinary Markdown under the vault — if the user prefers to pick and choose which sessions to keep, they can delete files manually and re-run teardown without `--purge`.
+
+### Path-safety gate
+
+Before any deletion runs, the script validates the layout at the configured vault path:
+
+- The configured vault must exist and be a directory.
+- `<vault>/claude-memory/` must exist and be a directory.
+- `<vault>/claude-memory/projects` must be either **absent** or a symlink that resolves (via plain `readlink`, no `-f`) to `$HOME/.claude/projects`.
+
+If any check fails, the script prints `REFUSED`, the detected vault path, the specific mismatch, and a hint pointing at `/obsidian-memory:doctor` for diagnosis — and exits non-zero **without deleting anything**. This catches the "user edited `config.json` to point at an unrelated directory" class of accident.
+
+### Idempotent
+
+Running teardown on an already-torn-down install is a no-op: if `~/.claude/obsidian-memory/config.json` is absent, the script prints "nothing to do" and exits 0 without touching the filesystem. Safe to re-run.
+
+## Exit Code Contract
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Success — includes a completed teardown, a cancelled purge, the idempotent nothing-to-do path, and every `--dry-run` invocation. |
+| `1` | Path-safety refusal — the layout at the configured vault does not match setup's footprint. Nothing was deleted. Run `/obsidian-memory:doctor` and reconcile. |
+| `2` | Bad usage — an unknown flag was passed. |
+
+## Error handling
+
+- **Missing `jq`**: required to read `vaultPath` from the config. The script treats this as a path-safety refusal (exit 1) with a hint to install `jq` — it will not guess at the vault path from another source.
+- **Missing `claude` on PATH** (only meaningful with `--unregister-mcp`): the MCP unregistration step prints a one-line non-fatal warning and the rest of the teardown still completes. Exit code stays 0.
+- **`claude mcp remove` exits non-zero or times out**: same non-fatal treatment — a one-line warning, teardown exit code stays 0.
+- **Non-interactive `--purge`** (stdin is not a TTY, e.g., piped from a script): the confirmation prompt reads EOF and cancels the purge. This is the correct failsafe; sessions are preserved.
+
+## Idempotency
+
+Teardown is idempotent by construction. Running it a second time after a successful run lands on the "no config found — nothing to do" branch and makes no filesystem changes. Running it against an already-partial install (e.g., symlink gone, config still present) still works: the script composes its plan against the state it finds, not against a rigid expected-shape.
+
+## Related skills
+
+- `/obsidian-memory:setup` wrote the footprint that teardown reverses. Re-run setup against a different vault path to "migrate" without losing the current config first.
+- `/obsidian-memory:doctor` diagnoses the install state read-only. Teardown's path-safety refusal message explicitly routes the user here: if the layout does not match what setup would have produced, doctor's per-check output identifies exactly which piece has drifted so the user can reconcile manually before re-running teardown.
+- `/obsidian-memory:distill-session` writes into `<vault>/claude-memory/sessions/`. If the user just wants to stop distilling without removing the config, running teardown is overkill — toggle the `distill` feature off instead.

--- a/specs/feature-add-obsidian-memory-teardown-skill/design.md
+++ b/specs/feature-add-obsidian-memory-teardown-skill/design.md
@@ -1,0 +1,380 @@
+# Design: Teardown Skill
+
+**Issues**: #3
+**Date**: 2026-04-21
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## Overview
+
+The teardown skill is the inverse of `/obsidian-memory:setup`. Its entry point is `skills/teardown/SKILL.md`, which instructs Claude to invoke a shell script (`scripts/vault-teardown.sh`) and relay its exit code and output. Putting the logic in a shell script — rather than in the SKILL's Markdown body — matches the doctor pattern (`feature-doctor-health-check-skill/`) and lets bats exercise every branch deterministically without spawning the Claude CLI.
+
+The script follows a strict three-stage sequence: **discover** (read config, resolve vault path), **validate** (path-safety gate against the setup layout), **act** (remove config + symlink by default; optionally remove sessions/Index.md after typed `yes`; optionally unregister the MCP server). The validation gate runs before any deletion, and every deletion path gates on it — there is no code path that removes anything before validation passes. This ordering is the single load-bearing safety property of the feature.
+
+The script is the only new runtime artifact. All tests run against a scratch `$HOME` using the existing `tests/helpers/scratch.bash` harness (shipped with issue #1). Integration tests can assert the destructive boundary by comparing mtime/cksum digests of `sessions/` and `Index.md` across every scenario — in every path that is not `--purge --yes`, those digests must be unchanged.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  User invokes /obsidian-memory:teardown [--purge]          │
+│                                         [--unregister-mcp] │
+│                                         [--dry-run]        │
+└────────────────────────┬───────────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│  skills/teardown/SKILL.md                                  │
+│   - documents the command, flags, safety guarantees        │
+│   - instructs Claude to run scripts/vault-teardown.sh      │
+│   - relays exit code + output verbatim                     │
+└────────────────────────┬───────────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│  scripts/vault-teardown.sh                                 │
+│   Stage 1: discover    → read $CONFIG, parse vaultPath     │
+│   Stage 2: validate    → path-safety gate on <vault>/      │
+│                            claude-memory/ layout           │
+│   Stage 3: plan        → enumerate removals + preservals   │
+│   Stage 3a (--dry-run) → print plan, exit 0                │
+│   Stage 3b (--purge)   → prompt for typed "yes"            │
+│   Stage 4: act         → unlink + rm in a fixed order      │
+│   Stage 5: --unregister-mcp (best-effort, non-fatal)       │
+│   Stage 6: summary + exit                                  │
+└─────┬──────────────────────────────────────────────────────┘
+      │
+      ▼ WRITES ONLY UNDER ~/.claude/obsidian-memory/ AND <vault>/claude-memory/
+┌──────────────────────┐  ┌──────────────────────┐  ┌──────────────────────┐
+│ $CONFIG JSON         │  │ $VAULT/claude-memory │  │ claude mcp remove    │
+│ (rm on ACT)          │  │ (unlink + rm -r)     │  │ (on --unregister-mcp)│
+└──────────────────────┘  └──────────────────────┘  └──────────────────────┘
+```
+
+### Data Flow
+
+```
+1. SKILL.md receives invocation → shells out to scripts/vault-teardown.sh with $ARGS.
+2. vault-teardown.sh parses flags (--purge, --unregister-mcp, --dry-run).
+3. Stage 1 — discover:
+     - If $CONFIG is not present → print "no obsidian-memory config found — nothing to do", exit 0.
+     - Else jq-parse .vaultPath; empty/null vaultPath → path-safety FAIL with hint.
+4. Stage 2 — validate (path-safety gate):
+     V1  <vault> exists and is a directory
+     V2  <vault>/claude-memory/ exists and is a directory
+     V3  <vault>/claude-memory/projects is either (a) a symlink resolving to $HOME/.claude/projects
+         (exact match after readlink, no -f), or (b) absent
+         → anything else (regular file, directory, symlink pointing elsewhere) = FAIL
+     V4  jq is available (needed for discover, but re-checked here as a defensive gate)
+     If any validator fails → print detected vault path + specific mismatch +
+                               "run /obsidian-memory:doctor to diagnose" hint, exit 1.
+5. Stage 3 — plan:
+     PLAN_REMOVE = [ $CONFIG, <vault>/claude-memory/projects (if symlink exists) ]
+     PLAN_PRESERVE = [ <vault>/claude-memory/sessions/, <vault>/claude-memory/Index.md ]
+     If --purge:
+       PLAN_REMOVE += <vault>/claude-memory/sessions/, <vault>/claude-memory/Index.md
+       PLAN_PRESERVE = []
+     If --unregister-mcp:
+       PLAN_REMOVE += "obsidian MCP server registration (via claude mcp remove)"
+6. Stage 3a — if --dry-run:
+     Print the plan with "WOULD REMOVE:" / "WOULD PRESERVE:" labels. Exit 0.
+7. Stage 3b — if --purge (and not --dry-run):
+     Print a count + the absolute paths that would be deleted.
+     Prompt: "Type 'yes' to delete these notes (anything else cancels): "
+     Read one line from stdin. EOF or any response != "yes" (case-sensitive exact) →
+       drop sessions/Index.md from PLAN_REMOVE, add them back to PLAN_PRESERVE,
+       print "sessions preserved — purge cancelled".
+8. Stage 4 — act (fixed order, every unlink/rm is guarded by absolute-path + path-safety pre-check):
+     a. unlink <vault>/claude-memory/projects  (if present)
+     b. if --purge confirmed:
+          rm -rf <vault>/claude-memory/sessions
+          rm -f  <vault>/claude-memory/Index.md
+          rmdir <vault>/claude-memory  (only if empty; swallow failure)
+     c. rm -f $CONFIG
+     d. rmdir ~/.claude/obsidian-memory  (only if empty; swallow failure)
+9. Stage 5 — if --unregister-mcp:
+     Run `timeout 3 claude mcp remove obsidian -s user` (or the current equivalent).
+     Non-zero exit → print one-line non-fatal warning, continue.
+10. Stage 6 — summary + exit 0 (success paths) or exit 1 (validation refusal) or exit 2 (bad args).
+```
+
+---
+
+## API / Interface Changes
+
+### New Skill
+
+| Skill | File | Invocation | Purpose |
+|-------|------|------------|---------|
+| `obsidian-memory:teardown` | `skills/teardown/SKILL.md` | `/obsidian-memory:teardown [--purge] [--unregister-mcp] [--dry-run]` | Inverse of setup — removes config + symlink, optionally purges distilled notes, optionally unregisters MCP |
+
+### New Script
+
+| Script | File | Args | Exit code |
+|--------|------|------|-----------|
+| `vault-teardown.sh` | `scripts/vault-teardown.sh` | `[--purge] [--unregister-mcp] [--dry-run]` | `0` on success (including idempotent + cancelled purge), `1` on path-safety refusal, `2` on bad usage |
+
+### Flag semantics
+
+| Flag combination | Behavior |
+|------------------|----------|
+| *(none)* | Remove config + symlink; preserve sessions + Index.md; do not touch MCP |
+| `--purge` | Default removals, plus sessions + Index.md after typed `yes` |
+| `--unregister-mcp` | Default removals, plus best-effort `claude mcp remove` |
+| `--purge --unregister-mcp` | Both of the above |
+| `--dry-run` | Print the plan; touch nothing; no MCP call; no prompt; exit 0 |
+| `--dry-run --purge` | Plan includes sessions+Index.md under WOULD REMOVE; still no prompt, still no deletion |
+| Any unknown flag | Exit 2 with a usage line |
+
+### Human-mode output format
+
+Default teardown, healthy install:
+
+```
+obsidian-memory teardown
+────────────────────────
+vault: /Users/x/Vault
+
+PLAN
+  REMOVE     ~/.claude/obsidian-memory/config.json
+  REMOVE     /Users/x/Vault/claude-memory/projects (symlink)
+  PRESERVE   /Users/x/Vault/claude-memory/sessions/  (12 notes)
+  PRESERVE   /Users/x/Vault/claude-memory/Index.md
+
+ACTIONS
+  REMOVED    /Users/x/Vault/claude-memory/projects
+  REMOVED    /Users/x/.claude/obsidian-memory/config.json
+
+Teardown complete. Distilled notes preserved.
+```
+
+Purge with confirmation:
+
+```
+obsidian-memory teardown --purge
+────────────────────────────────
+vault: /Users/x/Vault
+
+PLAN
+  REMOVE     ~/.claude/obsidian-memory/config.json
+  REMOVE     /Users/x/Vault/claude-memory/projects (symlink)
+  REMOVE     /Users/x/Vault/claude-memory/sessions/  (12 notes)
+  REMOVE     /Users/x/Vault/claude-memory/Index.md
+
+About to delete 12 distilled note file(s) under /Users/x/Vault/claude-memory/sessions/.
+Type 'yes' to confirm (anything else cancels): yes
+
+ACTIONS
+  REMOVED    /Users/x/Vault/claude-memory/projects
+  REMOVED    /Users/x/Vault/claude-memory/sessions/  (12 notes)
+  REMOVED    /Users/x/Vault/claude-memory/Index.md
+  REMOVED    /Users/x/.claude/obsidian-memory/config.json
+
+Teardown complete. Distilled notes deleted.
+```
+
+Purge cancelled:
+
+```
+...
+Type 'yes' to confirm (anything else cancels): y
+
+Sessions preserved — purge cancelled.
+
+ACTIONS
+  REMOVED    /Users/x/Vault/claude-memory/projects
+  PRESERVED  /Users/x/Vault/claude-memory/sessions/
+  PRESERVED  /Users/x/Vault/claude-memory/Index.md
+  REMOVED    /Users/x/.claude/obsidian-memory/config.json
+
+Teardown complete. Distilled notes preserved.
+```
+
+Path-safety refusal:
+
+```
+obsidian-memory teardown
+────────────────────────
+vault: /tmp/unrelated-dir
+
+REFUSED
+  /tmp/unrelated-dir does not contain a claude-memory/ directory.
+  This does not look like an obsidian-memory install — refusing to delete anything.
+  Run /obsidian-memory:doctor to diagnose the config, then reconcile manually.
+```
+
+Idempotent (nothing to do):
+
+```
+obsidian-memory teardown
+────────────────────────
+No obsidian-memory config found at ~/.claude/obsidian-memory/config.json — nothing to do.
+```
+
+### Exit code contract
+
+| Exit code | Condition |
+|-----------|-----------|
+| `0` | Successful teardown (any flag combination), cancelled purge, idempotent no-op, dry-run |
+| `1` | Path-safety refusal (AC4) |
+| `2` | Bad usage (unknown flag) |
+
+---
+
+## Database / Storage Changes
+
+None. Teardown is a destructive inverse of setup's filesystem footprint; it introduces no new persistent state.
+
+---
+
+## State Management
+
+No mutable state beyond local bash variables within a single process. The plan/act split is implemented in-process as two small arrays (`PLAN_REMOVE`, `PLAN_PRESERVE`) populated in Stage 3 and consumed in Stage 4.
+
+---
+
+## UI Components
+
+Not applicable (no GUI). See the output formats above for terminal "UI".
+
+### Confirmation prompt
+
+| Aspect | Specification |
+|--------|---------------|
+| Prompt text | `Type 'yes' to confirm (anything else cancels): ` |
+| Input source | stdin, single line via `read -r REPLY` |
+| Accept condition | `[ "$REPLY" = "yes" ]` — case-sensitive exact match on literal `yes` |
+| Reject conditions | Any other string, empty line, EOF, SIGINT |
+| Timeout | None — the prompt blocks until the user responds (EOF is a clean "no") |
+| TTY requirement | Not enforced — the prompt writes to stderr and reads from stdin, so a non-interactive invocation simply hits EOF immediately and cancels the purge, which is the correct failsafe behavior |
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Pros | Cons | Decision |
+|--------|-------------|------|------|----------|
+| **A: Logic in SKILL.md, no script** | Let Claude orchestrate each check by calling `Bash` many times. | One file; no new script. | Not bats-testable without invoking Claude; every deletion would need its own permission prompt; slow. | Rejected — untestable and slow. |
+| **B: Pure bash script, SKILL.md is a thin wrapper** | `scripts/vault-teardown.sh` does all the work; SKILL.md tells Claude to run it. | Bats-testable end to end; fast; single permission prompt; matches doctor pattern. | Two files instead of one. | **Selected**. |
+| **C: Default `--purge` ON; require `--no-purge` to preserve** | Mirror the "delete by default, flag to keep" pattern common in package managers. | Fewer flags to learn. | Distilled notes are the user's memory. The default must be the safe choice. | Rejected — violates the core safety principle in the issue and `steering/product.md`. |
+| **D: `-y/--yes` flag to skip typed-`yes` confirmation** | Let CI / automation suppress the prompt. | Scriptability. | The confirmation is the load-bearing guarantee that distilled notes are not accidentally deleted. An override flag eliminates it. | Rejected — no override. Anyone who truly wants unattended purge can `rm -rf` the sessions directory directly (they are plain Markdown). |
+| **E: Reuse `scripts/_common.sh::om_load_config`** | Borrow the existing config loader. | DRY. | `om_load_config` exits 0 on any failure (designed for hooks); teardown needs to *observe* a missing config and handle it differently from a mismatched layout. | Rejected — different failure semantics. Teardown reads the config directly with its own jq call, same as doctor does. |
+| **F: Tri-state path-safety (STRICT, LENIENT, OFF)** | Let the user relax the path-safety gate with a flag. | Flexibility for weird layouts. | Undermines the single load-bearing safety property. | Rejected — the mismatched-footprint path is always a refusal; the user is told to reconcile manually. |
+
+---
+
+## Security Considerations
+
+- [x] **Authentication**: None required. Teardown operates on user-owned files.
+- [x] **Authorization**: The script writes only under `~/.claude/obsidian-memory/` and `<vault>/claude-memory/`. The vault path comes exclusively from `config.json` (jq-parsed); no path is accepted from invocation flags. Any attempted write outside these subtrees would have to come from a `vaultPath` in the config that is validated by Stage 2 — and the path-safety gate refuses every layout that does not match setup's footprint.
+- [x] **Input Validation**: The only arguments are three named flags (`--purge`, `--unregister-mcp`, `--dry-run`). Any other argv value prints a usage line and exits 2. No shell interpolation of user input. The stdin confirmation is compared with `[ "$REPLY" = "yes" ]`, not evaluated or interpolated.
+- [x] **Data Sanitization**: Output that includes paths from the config is printed as plain text; no HTML, no shell echo expansion. ANSI escapes are emitted only when `stdout` is a TTY.
+- [x] **Sensitive Data**: Config contains only a vault path and enable flags — no secrets. Teardown does not log the config contents; it only reports paths that are already visible via `ls`.
+- [x] **Destructive safety** (new, specific to this skill): Every `rm` / `unlink` invocation uses an absolute path computed from the validated vault path. No `rm -rf $var` without absolute-path + path-safety pre-check. No variable expansion in an `rm` target that could be unset. The sessions and Index.md removals happen only after the typed-`yes` gate. The path-safety refusal exits before any deletion runs.
+
+---
+
+## Performance Considerations
+
+- [x] **Caching**: None needed. Each action is O(1) in filesystem ops.
+- [x] **Pagination**: N/A.
+- [x] **Lazy Loading**: N/A.
+- [x] **Indexing**: N/A.
+- [x] **Wall time**: Target < 500 ms in the common case. The `--unregister-mcp` path can add wall time bounded by `timeout 3`.
+- [x] **Large sessions directories**: `--purge` runs `rm -rf` on a directory that may contain thousands of files. This is not a hot path and is bounded by the filesystem's delete throughput. No progress indicator is needed — teardown is a deliberate one-shot user action.
+
+---
+
+## Testing Strategy
+
+| Layer | Type | Coverage |
+|-------|------|----------|
+| Script internals | bats unit | Not needed — stages are short and tested through integration. |
+| End-to-end | bats integration | `tests/integration/teardown.bats` with ≥1 test per AC plus parameterized tests for the typed-`yes` variants. |
+| Specification | BDD (cucumber-shell) | `specs/feature-add-obsidian-memory-teardown-skill/feature.gherkin` — every AC has a scenario. Step definitions in `tests/features/steps/teardown.sh`. |
+| Static | shellcheck | `scripts/vault-teardown.sh`, `tests/features/steps/teardown.sh`, any new `.bats`. |
+
+Scratch harness contract (reused from `tests/helpers/scratch.bash`):
+
+- `$HOME` is redirected to `$BATS_TEST_TMPDIR/home` for every test.
+- `$VAULT` and `$PLUGIN_ROOT` are pre-exported.
+- `assert_home_untouched` enforces that non-teardown-scoped paths under `$HOME` are unchanged (but teardown *does* modify `~/.claude/obsidian-memory/`, so tests will assert its specific pre/post state manually instead of calling the generic helper).
+- **New helper proposed**: `assert_sessions_untouched` — cksum digest of `$VAULT/claude-memory/sessions/` and `$VAULT/claude-memory/Index.md` taken in `setup()`, compared in `teardown()`. Every AC except AC2's `yes` branch asserts this helper. Lives at `tests/helpers/scratch.bash` alongside the existing `assert_home_untouched`.
+
+### Test matrix (minimum)
+
+| Test | Scenario |
+|------|----------|
+| happy_default | AC1 — healthy install, default flags |
+| purge_yes | AC2 — `--purge` with literal `yes` on stdin |
+| purge_y | AC2 — `--purge` with `y` on stdin (must cancel) |
+| purge_cap_YES | AC2 — `--purge` with `YES` (must cancel) |
+| purge_empty | AC2 — `--purge` with empty line (must cancel) |
+| purge_eof | AC2 — `--purge` with `</dev/null` (must cancel) |
+| unregister_mcp_ok | AC3 — `--unregister-mcp` with stub `claude` succeeding |
+| unregister_mcp_fail | AC3 — `--unregister-mcp` with stub `claude` returning non-zero (non-fatal) |
+| refuse_no_claude_memory | AC4 — vaultPath points at a dir without `claude-memory/` |
+| refuse_projects_not_symlink | AC4 — `<vault>/claude-memory/projects` is a regular directory |
+| refuse_projects_wrong_target | AC4 — symlink pointing somewhere other than `~/.claude/projects` |
+| refuse_vault_missing | AC4 — vaultPath points at a non-existent directory |
+| idempotent_no_config | AC5 — no config at all |
+| idempotent_after_default | AC5 — run default teardown, then run teardown again |
+| dry_run_healthy | AC6 — `--dry-run` on a healthy install, nothing mutates |
+| dry_run_purge | AC6 — `--dry-run --purge` prints sessions in WOULD REMOVE but does not prompt, does not delete |
+| dry_run_unregister | AC6 — `--dry-run --unregister-mcp` does not invoke `claude mcp remove` |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| An edited `config.json` points at an unrelated directory and teardown deletes user files | Low | **Critical** | Path-safety gate (Stage 2 / AC4) refuses every layout that does not look like setup's footprint. No `rm` runs before validation passes. Unit-tested in `refuse_*` tests. |
+| User types `y` expecting it to confirm and the sessions get deleted | Low | **Critical** | Typed-`yes` gate is case-sensitive exact match on literal `yes`. `y`, `Y`, `YES` all cancel the purge. Tested via parameterized scenarios. |
+| Non-interactive invocation (e.g., piped from a script) makes the prompt silently skip to EOF and deletes sessions | High without mitigation | **Critical** | EOF on stdin is treated as refusal. A non-interactive `--purge` cancels the purge — this is the correct failsafe and matches the spirit of the typed-`yes` rule. |
+| `readlink -f` is not portable on macOS default bash (BSD readlink lacks `-f`) | High | Medium | Use POSIX `readlink` without `-f`; compare result to `$HOME/.claude/projects` directly. Already the pattern used in `scripts/_common.sh` and `scripts/vault-doctor.sh`. |
+| `rmdir` on `<vault>/claude-memory/` fails because of hidden files | Medium | Low | Swallow the failure (`rmdir ... 2>/dev/null || true`). Leaving the directory is acceptable — it is not part of the core "removed" contract, just a cosmetic cleanup after a successful purge. |
+| `claude mcp remove` prompts or takes a long time | Low | Low | Wrap in `timeout 3`. Non-zero/timeout → single-line non-fatal warning. Mirrors doctor's MCP probe. |
+| Color codes leak into pipes | Low | Low | Gate every escape sequence on `[ -t 1 ]`. |
+| User runs teardown mid-session and a new distillation lands after the scan | Low | Low | Out of scope. Teardown is a one-shot deliberate action; concurrent writes are the user's responsibility. The `--purge` count displayed in the prompt is a snapshot, not a lock. |
+| `jq` is missing so we cannot read `vaultPath` | Medium | Medium | Stage 2 (V4) returns a path-safety refusal with a hint to install `jq`. Teardown exits 1 without deleting anything, same as the other refusal paths. |
+| A future change to setup's layout (e.g., a new artifact) is not reflected in teardown | Medium | Medium | Keep teardown's `PLAN_REMOVE` / `PLAN_PRESERVE` lists next to setup's documented layout in the SKILL.md so the coupling is visible. `/write-spec` amendments against `feature-vault-setup/` should call out teardown impact in Change History. |
+
+---
+
+## Open Questions
+
+None remaining. Each of the three requirements-level questions is resolved above:
+
+- Confirmation prompt is case-sensitive literal `yes` (Alternatives Considered Option D, Risks row 2).
+- `--dry-run` suppresses every side effect including MCP (Flag semantics table).
+- `rmdir <vault>/claude-memory/` is best-effort only (Risks row 5).
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #3 | 2026-04-21 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to TASKS phase:
+
+- [x] Architecture follows existing project patterns (SKILL.md + `scripts/*.sh`, per `structure.md`; mirrors doctor's shape)
+- [x] All interface changes documented (SKILL.md invocation + script CLI + exit code contract)
+- [x] No database/storage changes required (teardown is a filesystem inverse)
+- [x] No state management needed (single-process, no persistence)
+- [x] UI output defined (default, purge, cancelled-purge, refusal, idempotent formats)
+- [x] Security addressed (path-safety gate, absolute-path-only deletions, typed-`yes` gate)
+- [x] Performance budgeted (< 500 ms common case; `timeout 3` on MCP)
+- [x] Testing strategy defined (bats + BDD + shellcheck; explicit test matrix)
+- [x] Alternatives documented (6 options considered, including tri-state path-safety and `-y` override)
+- [x] Risks identified with mitigations (destructive-safety risks called out specifically)

--- a/specs/feature-add-obsidian-memory-teardown-skill/feature.gherkin
+++ b/specs/feature-add-obsidian-memory-teardown-skill/feature.gherkin
@@ -1,0 +1,196 @@
+# File: specs/feature-add-obsidian-memory-teardown-skill/feature.gherkin
+#
+# Generated from: specs/feature-add-obsidian-memory-teardown-skill/requirements.md
+# Issue: #3
+#
+# Every scenario runs under the bats scratch harness (tests/helpers/scratch.bash),
+# which redirects $HOME to $BATS_TEST_TMPDIR/home before any step fires. The
+# Background below documents that invariant; the harness itself is enforced by
+# tests/run-bdd.sh for every scenario.
+#
+# Scenario Outline is not supported by tests/run-bdd.sh, so each purge
+# cancellation input (`y`, `YES`, empty, EOF) and each path-safety mismatch
+# variant is its own explicit Scenario below. This mirrors the pattern in
+# specs/feature-doctor-health-check-skill/feature.gherkin.
+
+Feature: Teardown inverts obsidian-memory setup safely
+  As a Claude Code + Obsidian user who wants to uninstall or migrate vaults
+  I want a single teardown skill that is the exact inverse of /obsidian-memory:setup
+  So that I can cleanly remove the plugin's footprint without hand-tracing every path setup wrote to
+
+  Background:
+    Given a scratch $HOME at "$BATS_TEST_TMPDIR/home"
+    And   a scratch Obsidian vault at "$BATS_TEST_TMPDIR/vault"
+    And   a safe PATH with a stub claude is installed
+
+  # --- AC1: Default Teardown ---
+
+  Scenario: Default teardown removes config and symlink, preserves distilled notes
+    Given a baseline-healthy obsidian-memory install
+    And   the sessions directory contains 3 distilled note files
+    When  I run "/obsidian-memory:teardown"
+    Then  the config file at "~/.claude/obsidian-memory/config.json" no longer exists
+    And   the projects symlink under the vault no longer exists
+    And   the sessions directory under the vault is preserved byte-for-byte
+    And   the Index.md under the vault is preserved byte-for-byte
+    And   the teardown output contains "REMOVED"
+    And   the teardown output contains "PRESERVED"
+    And   the teardown exit code is 0
+
+  # --- AC2: --purge with Typed "yes" ---
+
+  Scenario: Purge with typed "yes" deletes distilled notes
+    Given a baseline-healthy obsidian-memory install
+    And   the sessions directory contains 5 distilled note files
+    When  I run "/obsidian-memory:teardown --purge" and type "yes" at the confirmation prompt
+    Then  the config file at "~/.claude/obsidian-memory/config.json" no longer exists
+    And   the projects symlink under the vault no longer exists
+    And   the sessions directory under the vault no longer exists
+    And   the Index.md under the vault no longer exists
+    And   the teardown output contains "Distilled notes deleted"
+    And   the teardown exit code is 0
+
+  # --- AC2: --purge Cancellation Variants ---
+
+  Scenario: Purge with "y" cancels the purge and preserves sessions
+    Given a baseline-healthy obsidian-memory install
+    And   the sessions directory contains 5 distilled note files
+    When  I run "/obsidian-memory:teardown --purge" and type "y" at the confirmation prompt
+    Then  the sessions directory under the vault is preserved byte-for-byte
+    And   the Index.md under the vault is preserved byte-for-byte
+    And   the teardown output contains "purge cancelled"
+    And   the teardown exit code is 0
+
+  Scenario: Purge with "YES" (uppercase) cancels the purge and preserves sessions
+    Given a baseline-healthy obsidian-memory install
+    And   the sessions directory contains 5 distilled note files
+    When  I run "/obsidian-memory:teardown --purge" and type "YES" at the confirmation prompt
+    Then  the sessions directory under the vault is preserved byte-for-byte
+    And   the Index.md under the vault is preserved byte-for-byte
+    And   the teardown output contains "purge cancelled"
+    And   the teardown exit code is 0
+
+  Scenario: Purge with an empty line cancels the purge and preserves sessions
+    Given a baseline-healthy obsidian-memory install
+    And   the sessions directory contains 5 distilled note files
+    When  I run "/obsidian-memory:teardown --purge" and type an empty line at the confirmation prompt
+    Then  the sessions directory under the vault is preserved byte-for-byte
+    And   the Index.md under the vault is preserved byte-for-byte
+    And   the teardown output contains "purge cancelled"
+    And   the teardown exit code is 0
+
+  Scenario: Purge with EOF on stdin cancels the purge and preserves sessions
+    Given a baseline-healthy obsidian-memory install
+    And   the sessions directory contains 5 distilled note files
+    When  I run "/obsidian-memory:teardown --purge" with no input on stdin
+    Then  the sessions directory under the vault is preserved byte-for-byte
+    And   the Index.md under the vault is preserved byte-for-byte
+    And   the teardown output contains "purge cancelled"
+    And   the teardown exit code is 0
+
+  # --- AC3: --unregister-mcp ---
+
+  Scenario: --unregister-mcp removes the MCP server registration
+    Given a baseline-healthy obsidian-memory install
+    And   a stub claude that succeeds on "mcp remove obsidian"
+    When  I run "/obsidian-memory:teardown --unregister-mcp"
+    Then  the stub claude was invoked with "mcp remove obsidian -s user"
+    And   the teardown output contains "MCP"
+    And   the teardown exit code is 0
+
+  Scenario: --unregister-mcp treats a non-zero claude exit as non-fatal
+    Given a baseline-healthy obsidian-memory install
+    And   a stub claude that exits non-zero on "mcp remove obsidian"
+    When  I run "/obsidian-memory:teardown --unregister-mcp"
+    Then  the teardown output contains "MCP"
+    And   the config file at "~/.claude/obsidian-memory/config.json" no longer exists
+    And   the projects symlink under the vault no longer exists
+    And   the teardown exit code is 0
+
+  # --- AC4: Path-Safety Refusal ---
+
+  Scenario: Refuses when the vault has no claude-memory directory
+    Given a baseline-healthy obsidian-memory install
+    And   the vault's "claude-memory" directory has been removed
+    When  I run "/obsidian-memory:teardown"
+    Then  the teardown output contains "REFUSED"
+    And   the teardown output contains "/obsidian-memory:doctor"
+    And   the config file at "~/.claude/obsidian-memory/config.json" still exists
+    And   the teardown exit code is non-zero
+
+  Scenario: Refuses when projects is a regular directory, not a symlink
+    Given a baseline-healthy obsidian-memory install
+    And   the projects entry under the vault is replaced with a regular directory
+    When  I run "/obsidian-memory:teardown"
+    Then  the teardown output contains "REFUSED"
+    And   the teardown output contains "/obsidian-memory:doctor"
+    And   the config file at "~/.claude/obsidian-memory/config.json" still exists
+    And   the projects directory under the vault is not removed
+    And   the teardown exit code is non-zero
+
+  Scenario: Refuses when the projects symlink targets an unrelated path
+    Given a baseline-healthy obsidian-memory install
+    And   the projects symlink under the vault targets an unrelated directory
+    When  I run "/obsidian-memory:teardown"
+    Then  the teardown output contains "REFUSED"
+    And   the teardown output contains "/obsidian-memory:doctor"
+    And   the config file at "~/.claude/obsidian-memory/config.json" still exists
+    And   the projects symlink under the vault still exists
+    And   the teardown exit code is non-zero
+
+  Scenario: Refuses when the configured vault path does not exist on disk
+    Given a baseline-healthy obsidian-memory install
+    And   the configured vaultPath has been moved to a non-existent directory
+    When  I run "/obsidian-memory:teardown"
+    Then  the teardown output contains "REFUSED"
+    And   the teardown output contains "/obsidian-memory:doctor"
+    And   the config file at "~/.claude/obsidian-memory/config.json" still exists
+    And   the teardown exit code is non-zero
+
+  # --- AC5: Idempotency ---
+
+  Scenario: Teardown with no config at all is a no-op
+    Given no obsidian-memory config exists
+    When  I run "/obsidian-memory:teardown"
+    Then  the teardown output contains "nothing to do"
+    And   no file under "~/.claude/obsidian-memory" is created
+    And   the teardown exit code is 0
+
+  Scenario: Running teardown twice is a no-op on the second run
+    Given a baseline-healthy obsidian-memory install
+    When  I run "/obsidian-memory:teardown"
+    And   I run "/obsidian-memory:teardown" again
+    Then  the second run's output contains "nothing to do"
+    And   the second run's exit code is 0
+
+  # --- AC6: --dry-run ---
+
+  Scenario: --dry-run on a healthy install prints the plan and touches nothing
+    Given a baseline-healthy obsidian-memory install
+    And   the sessions directory contains 4 distilled note files
+    When  I run "/obsidian-memory:teardown --dry-run"
+    Then  the teardown output contains "WOULD REMOVE"
+    And   the teardown output contains "WOULD PRESERVE"
+    And   the config file at "~/.claude/obsidian-memory/config.json" still exists
+    And   the projects symlink under the vault still exists
+    And   the sessions directory under the vault is preserved byte-for-byte
+    And   the Index.md under the vault is preserved byte-for-byte
+    And   the teardown exit code is 0
+
+  Scenario: --dry-run --purge lists sessions under WOULD REMOVE without prompting
+    Given a baseline-healthy obsidian-memory install
+    And   the sessions directory contains 4 distilled note files
+    When  I run "/obsidian-memory:teardown --dry-run --purge" with no input on stdin
+    Then  the teardown output contains "WOULD REMOVE"
+    And   the teardown output contains the sessions directory path under WOULD REMOVE
+    And   the teardown output does not contain a "Type 'yes'" prompt
+    And   the sessions directory under the vault is preserved byte-for-byte
+    And   the Index.md under the vault is preserved byte-for-byte
+    And   the teardown exit code is 0
+
+  Scenario: --dry-run --unregister-mcp does not invoke claude mcp remove
+    Given a baseline-healthy obsidian-memory install
+    And   a stub claude that records every invocation
+    When  I run "/obsidian-memory:teardown --dry-run --unregister-mcp"
+    Then  the stub claude was not invoked
+    And   the teardown exit code is 0

--- a/specs/feature-add-obsidian-memory-teardown-skill/requirements.md
+++ b/specs/feature-add-obsidian-memory-teardown-skill/requirements.md
@@ -1,0 +1,264 @@
+# Requirements: Teardown Skill
+
+**Issues**: #3
+**Date**: 2026-04-21
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## User Story
+
+**As a** Claude Code + Obsidian user who wants to uninstall or migrate vaults
+**I want** a single teardown skill that is the exact inverse of `/obsidian-memory:setup`
+**So that** I can cleanly remove the plugin's footprint without hand-tracing every path setup wrote to.
+
+---
+
+## Background
+
+`/obsidian-memory:setup` (issue #9, spec `feature-vault-setup/`) writes to several places during a healthy install:
+
+- `~/.claude/obsidian-memory/config.json`
+- `<vault>/claude-memory/sessions/` (created)
+- `<vault>/claude-memory/projects` (symlink → `~/.claude/projects`)
+- `<vault>/claude-memory/Index.md` (initialized when absent)
+- Optionally registers the Obsidian Claude Code MCP server at user scope.
+
+Removing the plugin today requires the user to `rm -rf ~/.claude/obsidian-memory/`, manually unlink `<vault>/claude-memory/projects`, decide whether to delete `<vault>/claude-memory/sessions/` (which contains their distilled memory), and manually unregister the MCP server. This is fragile, error-prone, and the sessions-deletion decision is ambiguous.
+
+This feature adds `/obsidian-memory:teardown`: a read-mostly skill that removes the setup footprint safely. **Distilled session notes are the user's memory** — the default behavior must never delete them, and the destructive `--purge` path gates on explicit typed "yes" confirmation, not a y/N default. Path-safety gates reject any vault that does not look like something setup created.
+
+Related context: issue #3 (this spec), issue #9 (`feature-vault-setup/` — the install path this inverts), issue #2 (`feature-doctor-health-check-skill/` — doctor should appear in teardown's failure messages for mismatched footprints).
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: Default teardown removes config and symlink, preserves distilled notes
+
+**Given** a healthy install (config present, `<vault>/claude-memory/projects` symlink present, `<vault>/claude-memory/Index.md` present, `<vault>/claude-memory/sessions/` present)
+**When** the user runs `/obsidian-memory:teardown` with no flags
+**Then** `~/.claude/obsidian-memory/config.json` is deleted
+**And** `<vault>/claude-memory/projects` symlink is removed
+**And** `<vault>/claude-memory/sessions/` is preserved untouched
+**And** `<vault>/claude-memory/Index.md` is preserved untouched
+**And** the MCP server registration is left alone
+**And** the skill prints exactly what it removed and what it preserved
+**And** the skill exits 0
+
+**Example**:
+- Given: scratch `$HOME` with a full healthy install at `$BATS_TEST_TMPDIR/vault`
+- When: `scripts/vault-teardown.sh` runs with no flags
+- Then: config file is gone, symlink is gone; `sessions/` and `Index.md` are byte-identical to their pre-teardown state
+
+### AC2: `--purge` deletes distilled notes after typed "yes" confirmation
+
+**Given** a healthy install with N distilled session notes under `<vault>/claude-memory/sessions/`
+**When** the user runs `/obsidian-memory:teardown --purge`
+**Then** the skill shows a count of note files and the absolute path that would be deleted
+**And** prompts for explicit confirmation (the user must type the literal string `yes`)
+**And** on `yes`, deletes `<vault>/claude-memory/sessions/` and `<vault>/claude-memory/Index.md` in addition to the default removals
+**And** on any other response (including `y`, `Y`, `YES`, empty line, EOF), skips the purge and reports that sessions were preserved
+**And** the skill exits 0 whether the user confirmed or refused
+
+### AC3: `--unregister-mcp` removes the MCP server registration
+
+**Given** the Obsidian MCP server is registered at user scope (as would be produced by `/obsidian-memory:setup` when the user opted in)
+**When** the user runs `/obsidian-memory:teardown --unregister-mcp`
+**Then** the skill runs the inverse of the setup registration command (`claude mcp remove obsidian -s user` or the current equivalent)
+**And** a successful removal is reported as removed
+**And** a non-zero exit from `claude mcp remove` (not registered, `claude` not on PATH, etc.) is reported as a one-line non-fatal message and does not block the remainder of teardown
+**And** the skill exits 0
+
+### AC4: Path-safety refusal on a mismatched footprint
+
+**Given** `~/.claude/obsidian-memory/config.json` has been edited so `vaultPath` points at a directory that does not contain a recognizable `claude-memory/` layout (i.e., `<vault>/claude-memory/` is missing, is not a directory, or `<vault>/claude-memory/projects` is not a symlink created by setup)
+**When** the user runs `/obsidian-memory:teardown` (with or without flags)
+**Then** the skill detects the mismatch before deleting anything
+**And** prints the detected vault path, the specific mismatch, and a one-line remediation hint that mentions `/obsidian-memory:doctor` (issue #2) for diagnosis
+**And** does not delete the config file, the symlink, the sessions directory, the Index.md, or anything else under the vault
+**And** the skill exits non-zero
+
+### AC5: Teardown is idempotent (nothing-to-do state)
+
+**Given** a fully torn-down state — no `~/.claude/obsidian-memory/config.json`, no `<vault>/claude-memory/projects` symlink, no `<vault>/claude-memory/sessions/`, no `<vault>/claude-memory/Index.md`
+**When** the user runs `/obsidian-memory:teardown` a second time
+**Then** the skill reports that there is nothing to do (no config found) with no errors
+**And** no file is created, modified, or deleted anywhere
+**And** the skill exits 0
+
+**Example**:
+- Given: scratch `$HOME` with no `~/.claude/obsidian-memory/` at all
+- When: `scripts/vault-teardown.sh` runs
+- Then: stdout contains "nothing to do" (or equivalent phrasing); exit code is 0
+
+### AC6: `--dry-run` prints what would be removed without touching anything
+
+**Given** a healthy install
+**When** the user runs `/obsidian-memory:teardown --dry-run` (or `/obsidian-memory:teardown --purge --dry-run`)
+**Then** the skill prints a plan listing every path that would be removed and every path that would be preserved
+**And** no file is created, modified, or deleted
+**And** no MCP command is invoked (even if `--unregister-mcp` is also passed)
+**And** the skill exits 0
+
+### Generated Gherkin Preview
+
+See [feature.gherkin](feature.gherkin) for the canonical BDD scenarios.
+
+```gherkin
+Feature: Teardown inverts obsidian-memory setup safely
+  As a Claude Code + Obsidian user who wants to uninstall or migrate vaults
+  I want a single teardown skill that is the exact inverse of /obsidian-memory:setup
+  So that I can cleanly remove the plugin's footprint without hand-tracing every path setup wrote to
+
+  Scenario: Default teardown removes config and symlink, preserves distilled notes
+    Given a baseline-healthy obsidian-memory install
+    When  I run "/obsidian-memory:teardown"
+    Then  the config file is removed
+    And   the projects symlink is removed
+    And   the sessions directory is preserved
+    And   the Index.md is preserved
+    And   the teardown exit code is 0
+
+  # ... all ACs become scenarios
+```
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR1 | Add `skills/teardown/SKILL.md` following the skill template in `steering/structure.md`. | Must | Issue #3 body mentions `plugins/obsidian-memory/skills/teardown/SKILL.md`; this repo is a standalone plugin, so skills live at `skills/` (see `structure.md` → Project Layout). |
+| FR2 | Implement teardown logic as a shell script under `scripts/` so bats can exercise every code path without invoking Claude. | Must | Mirrors the doctor pattern (SKILL.md delegates to a script). |
+| FR3 | Default behavior: remove config + symlink; preserve sessions + Index.md; leave MCP registration alone. | Must | Core inverse-of-setup contract. |
+| FR4 | `--purge` flag: after the default removals, additionally delete `sessions/` and `Index.md` only if the user types the literal string `yes` at the confirmation prompt. | Must | Exact string match on `yes`; any other input (including `y`, `YES`, empty, EOF) aborts the purge. |
+| FR5 | `--unregister-mcp` flag: inverse of setup's MCP registration. Non-zero exits from the underlying `claude mcp` command are reported as non-fatal. | Must | Uses `claude mcp remove obsidian -s user` (or current equivalent). |
+| FR6 | Path-safety check before any deletion: verify `<vault>/claude-memory/` exists as a directory and (at least) the `projects` symlink resolves to `~/.claude/projects` *or* is absent. If the layout is mismatched, refuse and exit non-zero. | Must | Prevents the "user edited config to point at an unrelated directory" class of accidents. |
+| FR7 | Idempotent — running teardown twice must be safe. Missing config is the "nothing to do" signal. | Must | Matches setup's idempotent property from `steering/product.md`. |
+| FR8 | BDD scenarios for: default teardown, `--purge` with `yes`, `--purge` with refusal, `--unregister-mcp`, mismatched footprint, double-teardown (idempotency), `--dry-run`. | Must | Lives at `specs/feature-add-obsidian-memory-teardown-skill/feature.gherkin`. |
+| FR9 | `--dry-run` flag printing what would be removed without touching anything. | Should | Combines with other flags (e.g., `--purge --dry-run` still prints both groups and touches nothing). |
+| FR10 | Output vocabulary is consistent with `/obsidian-memory:setup` and `/obsidian-memory:doctor` ("vault path", "config", "projects symlink", "sessions directory", "Index.md"). | Should | Reduces cognitive load across skills. |
+| FR11 | Exit codes: `0` on a successful teardown (including idempotent nothing-to-do, purge refusal, and dry-run); non-zero on bad args or path-safety refusal. | Must | Matches doctor's pattern: `1` on refuse, `2` on usage errors. |
+
+---
+
+## Non-Functional Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Performance** | Wall time < 500 ms in the common case; no network calls; no `claude -p` subprocess. `claude mcp remove` may add wall time in the `--unregister-mcp` path but is bounded by a `timeout 3` like doctor's MCP probe. |
+| **Security** | Only `unlink`, `rm -r` under the vault's `claude-memory/` subtree, and `rm` of the config file. No paths are accepted from invocation flags — the vault path comes from `config.json`. No `rm` accepts a relative path. All deletions are absolute and inside the verified `<vault>/claude-memory/` subtree or `~/.claude/obsidian-memory/`. |
+| **Accessibility** | Plain-text output works in every terminal. Color is an enhancement, not a requirement. |
+| **Reliability** | Teardown itself must never accidentally delete the user's notes. The path-safety gate (FR6) and the typed-`yes` gate (FR4) are the load-bearing safeguards — both must be in place before any deletion runs. |
+| **Platforms** | macOS default bash (3.2) and Linux bash 4+, per `steering/tech.md`. Uses only POSIX `rm`, `unlink`, `readlink` (no `-f`), and `test` — no GNU extensions. |
+
+---
+
+## UI/UX Requirements
+
+Teardown has no GUI. Its "UI" is terminal output and one confirmation prompt.
+
+| Element | Requirement |
+|---------|-------------|
+| **Structure** | Plan section (what will be removed / preserved) → optional confirmation prompt → action section (what actually happened) → summary line. |
+| **Confirmation prompt** | Only present for `--purge`. Exactly one prompt. Exact string match on `yes` — case-sensitive, no default. Reads from stdin; EOF is treated as refusal. |
+| **Vocabulary** | Reuse terms from `setup` and `doctor` ("vault path", "config", "projects symlink", "sessions directory", "Index.md"). |
+| **Color (TTY only)** | Status words color-coded (REMOVED red, PRESERVED green, WOULD REMOVE / WOULD PRESERVE yellow in dry-run, REFUSED bold red). Never colorize when `stdout` is piped. |
+| **Empty state** | The idempotent nothing-to-do state prints a single line ("no obsidian-memory config found — nothing to do") and exits 0. |
+| **Error state** | Path-safety refusal prints the detected vault path, the specific mismatch, and a hint referencing `/obsidian-memory:doctor`. |
+
+---
+
+## Data Requirements
+
+### Input Data
+
+| Field | Type | Validation | Required |
+|-------|------|------------|----------|
+| `--purge` flag | CLI flag | Presence only | No |
+| `--unregister-mcp` flag | CLI flag | Presence only | No |
+| `--dry-run` flag | CLI flag | Presence only | No |
+| stdin (purge confirmation) | string | Exact match on `yes` | Only when `--purge` is set and `--dry-run` is not |
+
+### Output Data
+
+| Field | Type | Description |
+|-------|------|-------------|
+| stdout | plain text | Plan + actions + summary; ANSI-colored on TTY, plain when piped |
+| Exit code | int | 0 on success (including idempotent and dry-run); 1 on path-safety refusal; 2 on bad usage |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+
+- [x] `/obsidian-memory:setup` — teardown inverts what setup did; vocabulary and paths must stay in lockstep
+- [x] `/obsidian-memory:doctor` (issue #2) — referenced in the path-safety failure hint so users get a clear remediation path
+- [x] `scripts/_common.sh` — **not** used at runtime (teardown reads the config directly for the same reason doctor does; see design Alternatives)
+
+### External Dependencies
+
+- [x] `jq` — required for reading `vaultPath` out of `config.json`. Missing `jq` produces a path-safety refusal with a hint to install `jq`.
+- [x] `claude` CLI — required only for the `--unregister-mcp` path. Missing `claude` on that path is reported non-fatally.
+
+### Blocked By
+
+- None. Issue #1 (bats-core + cucumber-shell harness) and issue #2 (doctor) are already shipped.
+
+---
+
+## Out of Scope
+
+- **Uninstalling the plugin itself from Claude Code.** That is `claude plugin uninstall obsidian-memory` and lives outside this plugin.
+- **Migrating sessions to a new vault.** Tracked separately if needed.
+- **Automatic teardown on setup-with-different-vault.** Setup's responsibility is its own; teardown is a deliberate user action.
+- **Deleting the vault itself.** Teardown only touches `<vault>/claude-memory/` and `~/.claude/obsidian-memory/`. The vault directory is user-owned.
+- **Restoring or recovering distilled notes after `--purge`.** There is no undo. This is why `--purge` requires a typed `yes`.
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| User-owned data preservation | 100% — no regression test ever records a deleted sessions/ or Index.md under default teardown | Integration test asserts sessions/ and Index.md contents are byte-identical pre/post default teardown |
+| Path-safety catches | 100% of the mismatched-footprint scenarios in AC4 refuse before any deletion | Integration test per mismatch variant |
+| Typed-`yes` discipline | 100% — any input other than literal `yes` aborts the purge | Parameterized bats test with `y`, `Y`, `YES`, empty, EOF, `yes\n` all produce the correct outcomes |
+| Idempotency | Running teardown twice produces no errors and no filesystem changes on the second run | Integration test runs teardown twice and asserts the second run is a no-op |
+
+---
+
+## Open Questions
+
+- [x] Should the purge prompt be case-insensitive? — **Resolved: no.** Case-sensitive literal `yes` is the spec. Distilled sessions are durable memory; an accidental `Y` must not delete them.
+- [x] Should `--dry-run` also work with `--unregister-mcp`? — **Resolved: yes.** `--dry-run` suppresses every side effect, including the MCP command.
+- [x] Should teardown remove an empty `<vault>/claude-memory/` directory after default teardown? — **Resolved: no.** If the default run preserves `sessions/` and `Index.md`, the parent is non-empty by definition. If they were separately removed (via `--purge`), teardown may `rmdir` the parent only if it is empty; otherwise leave it alone.
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #3 | 2026-04-21 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to PLAN phase:
+
+- [x] User story follows "As a / I want / So that" format
+- [x] All acceptance criteria use Given/When/Then format
+- [x] No implementation details in requirements (design.md will cover how)
+- [x] All criteria are testable and unambiguous
+- [x] Success metrics are measurable
+- [x] Edge cases (path mismatch, idempotency, dry-run, EOF on confirmation) are specified
+- [x] Dependencies are identified
+- [x] Out of scope is defined
+- [x] Open questions are documented and resolved

--- a/specs/feature-add-obsidian-memory-teardown-skill/tasks.md
+++ b/specs/feature-add-obsidian-memory-teardown-skill/tasks.md
@@ -1,0 +1,232 @@
+# Tasks: Teardown Skill
+
+**Issues**: #3
+**Date**: 2026-04-21
+**Status**: Planning
+**Author**: Rich Nunley
+
+---
+
+## Summary
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Setup | 1 | [ ] |
+| Backend | 3 | [ ] |
+| Integration | 1 | [ ] |
+| Testing | 3 | [ ] |
+| **Total** | 8 | |
+
+"Backend" means the shell script implementation; "Integration" means the user-facing skill wrapper.
+
+---
+
+## Task Format
+
+```
+### T[NNN]: [Task Title]
+
+**File(s)**: `path/to/file`
+**Type**: Create | Modify
+**Depends**: T[NNN] (or None)
+**Acceptance**:
+- [ ] [Verifiable criterion]
+```
+
+---
+
+## Phase 1: Setup
+
+### T001: Create feature directory structure
+
+**File(s)**: `skills/teardown/`, `scripts/`, `tests/integration/`, `tests/features/steps/`
+**Type**: Create (directories only; actual files created in later tasks)
+**Depends**: None
+**Acceptance**:
+- [ ] `skills/teardown/` exists (empty, ready for SKILL.md in T005)
+- [ ] `scripts/`, `tests/integration/`, `tests/features/steps/` already exist from prior work — verify presence, create if missing
+- [ ] No existing files overwritten
+
+**Notes**: Low-risk directory prep task. Combines creation with presence verification so the task is safely idempotent. Mirrors the setup used in `feature-doctor-health-check-skill/tasks.md` T001.
+
+---
+
+## Phase 2: Backend Implementation
+
+### T002: Implement `vault-teardown.sh` core (discover, validate, plan, default act)
+
+**File(s)**: `scripts/vault-teardown.sh`
+**Type**: Create
+**Depends**: T001
+**Acceptance**:
+- [ ] Shebang `#!/usr/bin/env bash`; `set -u`; `trap` at top level per `steering/tech.md` Bash standards
+- [ ] Parses `--purge`, `--unregister-mcp`, `--dry-run` flags; anything else prints a usage line and exits 2
+- [ ] **Stage 1 (discover)**: reads `$HOME/.claude/obsidian-memory/config.json`; if missing, prints `"no obsidian-memory config found — nothing to do"` and exits 0
+- [ ] **Stage 1**: uses `jq` to parse `.vaultPath`; missing/null → falls through to path-safety refusal in Stage 2
+- [ ] **Stage 2 (path-safety gate)** implements validators V1–V4 from `design.md` → Data Flow:
+  - V1 `<vault>` is an existing directory
+  - V2 `<vault>/claude-memory/` is an existing directory
+  - V3 `<vault>/claude-memory/projects` is either a symlink resolving (via plain `readlink`, no `-f`) to `$HOME/.claude/projects`, or absent
+  - V4 `jq` is available
+- [ ] Any V1–V4 failure → print detected vault path, specific mismatch, and remediation hint referencing `/obsidian-memory:doctor`; exit 1
+- [ ] **Stage 3 (plan)**: populates `PLAN_REMOVE` and `PLAN_PRESERVE` bash arrays per `design.md` → Data Flow step 5
+- [ ] **Stage 4 (default act)**: `unlink` the projects symlink (if present), then `rm -f` the config file; `rmdir` `~/.claude/obsidian-memory` and `<vault>/claude-memory` only if empty, swallowing failures
+- [ ] Every `rm`/`unlink` target is an absolute path that was already validated in Stage 2 — no relative paths, no unset-variable expansions
+- [ ] Human output format matches the samples in `design.md` → Human-mode output format (default teardown and refusal samples)
+- [ ] ANSI color codes emitted only when `[ -t 1 ]`
+- [ ] Exits 0 on a successful default teardown
+- [ ] Passes `shellcheck scripts/vault-teardown.sh`
+
+**Notes**: Do NOT reuse `scripts/_common.sh::om_load_config` — it exits 0 on any failure, which masks the diagnoses teardown must surface. Teardown reads the config directly, same rationale as doctor (see Alternatives Considered Option E in `design.md`). The destructive boundary MUST NOT be crossed before Stage 2 returns OK — this is the single load-bearing safety property.
+
+### T003: Add `--purge` flow with typed-`yes` confirmation
+
+**File(s)**: `scripts/vault-teardown.sh` (extends T002)
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] When `--purge` is passed (and `--dry-run` is not), Stage 3b prompts on stderr: `"About to delete N distilled note file(s) under <abs-path>."` then `"Type 'yes' to confirm (anything else cancels): "`
+- [ ] Reads exactly one line from stdin via `read -r REPLY` (no timeout)
+- [ ] Accepts the purge only when `[ "$REPLY" = "yes" ]` — case-sensitive exact match on the literal string `yes`
+- [ ] `y`, `Y`, `YES`, empty line, EOF, and any other input cancel the purge
+- [ ] On cancel: `sessions/` and `Index.md` are moved from `PLAN_REMOVE` back into `PLAN_PRESERVE`; prints `"Sessions preserved — purge cancelled."`
+- [ ] On confirm: `rm -rf "<vault>/claude-memory/sessions"` and `rm -f "<vault>/claude-memory/Index.md"` run between the symlink removal and the config removal
+- [ ] The confirmation is reached only after Stage 2 returned OK — a path-safety refusal must never run the prompt
+- [ ] Exits 0 whether the purge confirmed or cancelled
+- [ ] Passes `shellcheck scripts/vault-teardown.sh`
+
+**Notes**: Do not add a `-y`/`--yes` flag that bypasses the prompt — explicitly rejected in `design.md` → Alternatives Considered Option D. Anyone who needs unattended purge can delete the plain-Markdown notes directly.
+
+### T004: Add `--unregister-mcp` flow and `--dry-run` flag
+
+**File(s)**: `scripts/vault-teardown.sh` (extends T002 and T003)
+**Type**: Modify
+**Depends**: T002, T003
+**Acceptance**:
+- [ ] `--unregister-mcp`: after Stage 4, runs `timeout 3 claude mcp remove obsidian -s user` (matches the inverse of `/obsidian-memory:setup` Step 5's registration command)
+- [ ] A non-zero exit or timeout from the MCP command is treated as non-fatal: prints a one-line warning; teardown exit code stays 0
+- [ ] If `claude` is not on PATH, prints the same non-fatal warning (no crash)
+- [ ] `--dry-run`: after Stage 3 (plan), prints the plan with `WOULD REMOVE:` / `WOULD PRESERVE:` labels, then exits 0. Does NOT prompt. Does NOT invoke any `rm`/`unlink`/`rmdir`. Does NOT invoke `claude mcp remove` (even when combined with `--unregister-mcp`)
+- [ ] `--dry-run` combined with `--purge` includes `sessions/` and `Index.md` under WOULD REMOVE without prompting
+- [ ] Human output matches the purge/cancelled/refusal samples in `design.md` → Human-mode output format
+- [ ] Exit code policy from `design.md` → Exit code contract is enforced across every flag combination
+- [ ] Passes `shellcheck scripts/vault-teardown.sh`
+
+**Notes**: Wrap the MCP command in `timeout 3` exactly as `scripts/vault-doctor.sh` does for its MCP probe, so the skill is never slow on a machine where `claude` is misbehaving.
+
+---
+
+## Phase 3: Integration
+
+### T005: Write `skills/teardown/SKILL.md`
+
+**File(s)**: `skills/teardown/SKILL.md`
+**Type**: Create
+**Depends**: T002, T003, T004
+**Acceptance**:
+- [ ] Frontmatter follows the template in `steering/structure.md` → File Templates → Skill template
+- [ ] `name: teardown`; `description:` includes trigger phrases ("uninstall obsidian memory", "remove obsidian-memory", "tear down obsidian memory", "inverse of setup", "/obsidian-memory:teardown")
+- [ ] `allowed-tools: Bash, Read` (no Write/Edit — the script performs deletions; the skill is a thin relayer)
+- [ ] `model: sonnet`, `effort: low` (matches `setup` and `doctor`)
+- [ ] Body documents the three flags (`--purge`, `--unregister-mcp`, `--dry-run`), the typed-`yes` guarantee, the path-safety guarantee, and the exit code contract
+- [ ] "When to Use" and "When NOT to Use" sections present; "When NOT to Use" calls out `claude plugin uninstall obsidian-memory` and vault migration as explicitly out of scope
+- [ ] Instructs Claude to invoke `"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/obsidian-memory}/scripts/vault-teardown.sh"` (with `"$@"`), relay the script's exit code and output verbatim, and never call the script twice in one invocation
+- [ ] Mentions that `--purge` is destructive and not reversible, and that distilled notes are plain Markdown the user can also delete manually if they prefer
+- [ ] Cross-links to `/obsidian-memory:doctor` in the path-safety refusal hint and to `/obsidian-memory:setup` in the Related Skills section
+
+**Notes**: The SKILL.md is intentionally thin — Claude shells out to the script and reports back, no re-interpretation of results. This preserves the bats-testable contract for the underlying logic.
+
+---
+
+## Phase 5: BDD Testing (Required)
+
+**Every acceptance criterion MUST have a Gherkin scenario.**
+
+### T006: Write BDD feature file
+
+**File(s)**: `specs/feature-add-obsidian-memory-teardown-skill/feature.gherkin`
+**Type**: Create
+**Depends**: None (can be drafted in parallel with T002)
+**Acceptance**:
+- [ ] One or more scenarios per AC from `requirements.md`:
+  - AC1 → `Scenario: Default teardown removes config and symlink, preserves distilled notes`
+  - AC2 → `Scenario: Purge with typed 'yes' deletes distilled notes` plus one cancellation scenario per representative rejection input (`y`, `YES`, empty, EOF)
+  - AC3 → `Scenario: --unregister-mcp removes the MCP server registration` plus one non-fatal-failure scenario
+  - AC4 → at least three mismatch variants (no `claude-memory/`, projects is not a symlink, symlink points elsewhere)
+  - AC5 → `Scenario: Double teardown is a no-op` and `Scenario: Teardown with no config is a no-op`
+  - AC6 → `Scenario: --dry-run on a healthy install touches nothing` and `Scenario: --dry-run --purge lists sessions without prompting`
+- [ ] Uses a `Background:` block declaring the scratch `$HOME` harness so every scenario runs under `tests/helpers/scratch.bash` — mirrors the pattern in `feature-doctor-health-check-skill/feature.gherkin`
+- [ ] Valid Gherkin syntax — `tests/run-bdd.sh` parses the file without error
+- [ ] Uses declarative phrasing ("I run /obsidian-memory:teardown"), not implementation details
+- [ ] No `Scenario Outline:` (not supported by `tests/run-bdd.sh` — each variant is its own explicit scenario)
+
+### T007: Implement step definitions
+
+**File(s)**: `tests/features/steps/teardown.sh`
+**Type**: Create
+**Depends**: T002, T003, T004, T006
+**Acceptance**:
+- [ ] One step definition per unique Given/When/Then phrase in `feature.gherkin`
+- [ ] Step definitions follow the naming convention in `steering/tech.md` → Step Definitions (function name mirrors the step phrasing, `lower_snake_case`)
+- [ ] All filesystem state lives under `$BATS_TEST_TMPDIR` per the scratch harness contract
+- [ ] Invokes the script under test via `"$PLUGIN_ROOT/scripts/vault-teardown.sh"`
+- [ ] Purge confirmation inputs (`yes`, `y`, `YES`, empty, EOF) are supplied via process stdin (e.g., `printf '%s\n' yes | vault-teardown.sh --purge`)
+- [ ] MCP command is stubbed via `tests/helpers/fake-claude.bash` (or a shim in the scratch `PATH`) — never invokes the user's real `claude`
+- [ ] `tests/run-bdd.sh` passes with every scenario green
+- [ ] Passes `shellcheck tests/features/steps/teardown.sh`
+
+### T008: Add bats integration test
+
+**File(s)**: `tests/integration/teardown.bats`, plus a new `assert_sessions_untouched` helper in `tests/helpers/scratch.bash`
+**Type**: Create (teardown.bats) + Modify (scratch.bash)
+**Depends**: T002, T003, T004
+**Acceptance**:
+- [ ] `setup()` loads `../helpers/scratch`, materializes a baseline-healthy install (config, symlink, `sessions/` with N fake notes, `Index.md`), and snapshots a cksum digest of `sessions/` + `Index.md` for `assert_sessions_untouched`
+- [ ] `teardown()` calls `assert_sessions_untouched` on every test EXCEPT the `--purge --yes` and double-teardown-after-purge cases
+- [ ] One `@test` per row of the test matrix in `design.md` → Testing Strategy (happy_default, purge_yes, purge_y, purge_cap_YES, purge_empty, purge_eof, unregister_mcp_ok, unregister_mcp_fail, refuse_no_claude_memory, refuse_projects_not_symlink, refuse_projects_wrong_target, refuse_vault_missing, idempotent_no_config, idempotent_after_default, dry_run_healthy, dry_run_purge, dry_run_unregister) — 17 tests total
+- [ ] Each refuse_* test asserts exit code 1, a `REFUSED` line in stdout, and the post-test existence of the config, symlink, `sessions/`, and `Index.md` (none deleted)
+- [ ] Each dry_run_* test asserts exit code 0 and byte-identical pre/post filesystem state (including the config, symlink, sessions, and Index.md)
+- [ ] The purge_yes test is the ONLY test whose post-state deletes `sessions/` and `Index.md`
+- [ ] `bats tests/integration/teardown.bats` passes
+- [ ] `tests/helpers/scratch.bash` `assert_sessions_untouched` helper uses the same cksum-digest pattern as `assert_home_untouched`
+
+**Notes**: The purge cancellation variants (`y`, `YES`, empty, EOF) are the most subtle branch — parameterize them as separate `@test` functions rather than looping, so bats reports each input on its own line. Stub `claude` in the scratch `PATH` for the two `--unregister-mcp` variants; for `unregister_mcp_fail` use a stub that `exit 1`s deterministically.
+
+---
+
+## Dependency Graph
+
+```
+T001 ──┬──▶ T002 ──▶ T003 ──▶ T004 ──┬──▶ T005
+       │                              │
+       │                              └──▶ T008
+       │
+       └──▶ T006 ──▶ T007 (also depends on T004)
+```
+
+Critical path: T001 → T002 → T003 → T004 → T005 (skill surface reaches the user).
+Independent track: T006 can start as soon as requirements.md is approved; T007 joins once T006 and T004 both land; T008 joins once T004 lands.
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #3 | 2026-04-21 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to IMPLEMENT phase:
+
+- [x] Each task has single responsibility
+- [x] Dependencies are correctly mapped
+- [x] Tasks can be completed independently (given dependencies)
+- [x] Acceptance criteria are verifiable
+- [x] File paths reference actual project structure (per `steering/structure.md`)
+- [x] Test tasks are included for each implementation task
+- [x] No circular dependencies
+- [x] Tasks are in logical execution order
+- [x] Destructive-path tasks explicitly call out the load-bearing safety invariants (path-safety gate, typed-`yes` gate)

--- a/tests/features/steps/teardown.sh
+++ b/tests/features/steps/teardown.sh
@@ -1,0 +1,330 @@
+# tests/features/steps/teardown.sh — step definitions for
+# specs/feature-add-obsidian-memory-teardown-skill/feature.gherkin (#3).
+#
+# Exercises scripts/vault-teardown.sh end-to-end against the scratch harness.
+# Every filesystem mutation lives under $BATS_TEST_TMPDIR — the operator's
+# real ~/.claude and real vault are never touched.
+
+# shellcheck shell=bash
+# shellcheck disable=SC2154,SC2153
+
+# Per-scenario state.
+T_STDOUT=""
+T_STDERR=""
+T_RC=0
+
+_teardown_config_path() {
+  printf '%s' "$HOME/.claude/obsidian-memory/config.json"
+}
+
+_teardown_install_safe_path_with_stub_claude() {
+  local bindir="$BATS_TEST_TMPDIR/teardownbin"
+  if [ -f "$bindir/.initialized" ]; then
+    PATH="$bindir"
+    export PATH
+    return 0
+  fi
+
+  mkdir -p "$bindir"
+  local d f name
+  local IFS_SAVED="$IFS"
+  IFS=':'
+  for d in $PATH; do
+    [ -d "$d" ] || continue
+    for f in "$d"/*; do
+      [ -x "$f" ] || continue
+      name="$(basename "$f")"
+      [ -e "$bindir/$name" ] && continue
+      ln -s "$f" "$bindir/$name" 2>/dev/null || true
+    done
+  done
+  IFS="$IFS_SAVED"
+
+  T_CLAUDE_LOG="$BATS_TEST_TMPDIR/claude.log"
+  export T_CLAUDE_LOG
+  : > "$T_CLAUDE_LOG"
+
+  _teardown_install_stub_claude succeed
+  : > "$bindir/.initialized"
+
+  PATH="$bindir"
+  export PATH
+}
+
+# Install a stub claude with the requested behavior for `mcp remove obsidian`.
+# Mode:
+#   succeed — exit 0, log the invocation
+#   fail    — exit 1, log the invocation
+_teardown_install_stub_claude() {
+  local mode="${1:-succeed}"
+  local bindir="$BATS_TEST_TMPDIR/teardownbin"
+  local exit_rc
+  case "$mode" in
+    succeed) exit_rc=0 ;;
+    fail)    exit_rc=1 ;;
+    *) return 1 ;;
+  esac
+
+  rm -f "$bindir/claude"
+  cat > "$bindir/claude" <<CLAUDE
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$T_CLAUDE_LOG"
+exit $exit_rc
+CLAUDE
+  chmod +x "$bindir/claude"
+}
+
+_teardown_baseline_healthy() {
+  mkdir -p "$HOME/.claude/projects" "$HOME/.claude/obsidian-memory"
+  cat > "$(_teardown_config_path)" <<EOF
+{"vaultPath":"$VAULT","rag":{"enabled":true},"distill":{"enabled":true}}
+EOF
+  mkdir -p "$VAULT/claude-memory/sessions"
+  ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+  printf '# Claude Memory Index\n\n## Sessions\n' > "$VAULT/claude-memory/Index.md"
+}
+
+_teardown_seed_sessions() {
+  local count="$1" i
+  mkdir -p "$VAULT/claude-memory/sessions/proj"
+  for (( i = 1; i <= count; i++ )); do
+    printf 'note %d\n' "$i" > "$VAULT/claude-memory/sessions/proj/note-$i.md"
+  done
+  snapshot_sessions
+}
+
+_teardown_run() {
+  local stdin_input="${1-}"
+  shift || true
+
+  T_STDERR="$(mktemp "$BATS_TEST_TMPDIR/teardown.err.XXXXXX")"
+  local script="$PLUGIN_ROOT/scripts/vault-teardown.sh"
+  if [ "$stdin_input" = "__NO_STDIN__" ]; then
+    if [ "$#" -gt 0 ]; then
+      T_STDOUT="$("$script" "$@" </dev/null 2>"$T_STDERR")"
+    else
+      T_STDOUT="$("$script" </dev/null 2>"$T_STDERR")"
+    fi
+  else
+    # printf '%s\n' ensures the purge-prompt read sees a complete line —
+    # command substitution on a caller-supplied `yes` stripped the trailing
+    # newline, which triggered the EOF-cancels-purge branch in the script.
+    if [ "$#" -gt 0 ]; then
+      T_STDOUT="$(printf '%s\n' "$stdin_input" | "$script" "$@" 2>"$T_STDERR")"
+    else
+      T_STDOUT="$(printf '%s\n' "$stdin_input" | "$script" 2>"$T_STDERR")"
+    fi
+  fi
+  T_RC=$?
+}
+
+# Strip the "/obsidian-memory:teardown" prefix, leaving the flag string.
+_teardown_flags() {
+  local cmd="$1"
+  printf '%s' "${cmd#"/obsidian-memory:teardown"}"
+}
+
+# ------------------------------------------------------------
+# Given steps
+# ------------------------------------------------------------
+
+given_a_safe_path_with_a_stub_claude_is_installed() {
+  _teardown_install_safe_path_with_stub_claude
+}
+
+given_a_baseline_healthy_obsidian_memory_install() {
+  _teardown_install_safe_path_with_stub_claude
+  _teardown_baseline_healthy
+  snapshot_sessions
+}
+
+# The gherkin bakes the sessions count into the step phrase (3/4/5 are
+# bare numbers, not quoted literals), so each count needs its own function.
+given_the_sessions_directory_contains_3_distilled_note_files() {
+  _teardown_seed_sessions 3
+}
+
+given_the_sessions_directory_contains_4_distilled_note_files() {
+  _teardown_seed_sessions 4
+}
+
+given_the_sessions_directory_contains_5_distilled_note_files() {
+  _teardown_seed_sessions 5
+}
+
+given_a_stub_claude_that_succeeds_on() {
+  _teardown_install_stub_claude succeed
+  : > "$T_CLAUDE_LOG"
+}
+
+given_a_stub_claude_that_exits_non_zero_on() {
+  _teardown_install_stub_claude fail
+  : > "$T_CLAUDE_LOG"
+}
+
+given_a_stub_claude_that_records_every_invocation() {
+  _teardown_install_stub_claude succeed
+  : > "$T_CLAUDE_LOG"
+}
+
+given_the_vault_s_directory_has_been_removed() {
+  # Arg: "claude-memory"
+  rm -rf "$VAULT/claude-memory"
+}
+
+given_the_projects_entry_under_the_vault_is_replaced_with_a_regular_directory() {
+  rm -rf "$VAULT/claude-memory/projects"
+  mkdir -p "$VAULT/claude-memory/projects/subdir"
+  printf 'marker\n' > "$VAULT/claude-memory/projects/keep.txt"
+}
+
+given_the_projects_symlink_under_the_vault_targets_an_unrelated_directory() {
+  rm -f "$VAULT/claude-memory/projects"
+  mkdir -p "$BATS_TEST_TMPDIR/unrelated"
+  ln -s "$BATS_TEST_TMPDIR/unrelated" "$VAULT/claude-memory/projects"
+}
+
+given_the_configured_vaultpath_has_been_moved_to_a_non_existent_directory() {
+  local bogus="$BATS_TEST_TMPDIR/vault-moved-away"
+  mkdir -p "$(dirname "$(_teardown_config_path)")"
+  cat > "$(_teardown_config_path)" <<EOF
+{"vaultPath":"$bogus","rag":{"enabled":true},"distill":{"enabled":true}}
+EOF
+}
+
+given_no_obsidian_memory_config_exists() {
+  _teardown_install_safe_path_with_stub_claude
+  rm -rf "$HOME/.claude/obsidian-memory"
+}
+
+# ------------------------------------------------------------
+# When steps
+# ------------------------------------------------------------
+
+when_i_run() {
+  local flags
+  flags="$(_teardown_flags "${1:-/obsidian-memory:teardown}")"
+  # shellcheck disable=SC2086
+  _teardown_run "" $flags
+}
+
+when_i_run_and_type_at_the_confirmation_prompt() {
+  # Args: "/obsidian-memory:teardown --purge", "yes"|"y"|"YES"
+  local flags
+  flags="$(_teardown_flags "$1")"
+  # shellcheck disable=SC2086
+  _teardown_run "$(printf '%s\n' "$2")" $flags
+}
+
+when_i_run_and_type_an_empty_line_at_the_confirmation_prompt() {
+  # Arg: "/obsidian-memory:teardown --purge"
+  local flags
+  flags="$(_teardown_flags "$1")"
+  # shellcheck disable=SC2086
+  _teardown_run "$(printf '\n')" $flags
+}
+
+when_i_run_with_no_input_on_stdin() {
+  # Arg: "/obsidian-memory:teardown --purge" (also used by --dry-run variants)
+  local flags
+  flags="$(_teardown_flags "$1")"
+  # shellcheck disable=SC2086
+  _teardown_run "__NO_STDIN__" $flags
+}
+
+when_i_run_again() {
+  when_i_run "$@"
+}
+
+# ------------------------------------------------------------
+# Then steps
+# ------------------------------------------------------------
+
+then_the_teardown_output_contains() {
+  local needle="${1:-}"
+  printf '%s' "$T_STDOUT" | grep -qF -- "$needle"
+}
+
+then_the_teardown_output_does_not_contain_a_prompt() {
+  # The "Type 'yes'" prompt is written to stderr, not stdout. Stream both.
+  local combined
+  combined="$T_STDOUT"$'\n'"$(cat "$T_STDERR" 2>/dev/null || true)"
+  ! printf '%s' "$combined" | grep -qF "Type 'yes'"
+}
+
+then_the_teardown_output_contains_the_sessions_directory_path_under_would_remove() {
+  local sessions="$VAULT/claude-memory/sessions"
+  printf '%s' "$T_STDOUT" | grep -qE "WOULD REMOVE[[:space:]]+${sessions}"
+}
+
+then_the_teardown_exit_code_is_0() {
+  [ "$T_RC" -eq 0 ]
+}
+
+then_the_teardown_exit_code_is_non_zero() {
+  [ "$T_RC" -ne 0 ]
+}
+
+then_the_config_file_at_no_longer_exists() {
+  [ ! -e "$(_teardown_config_path)" ]
+}
+
+then_the_config_file_at_still_exists() {
+  [ -f "$(_teardown_config_path)" ]
+}
+
+then_the_projects_symlink_under_the_vault_no_longer_exists() {
+  [ ! -e "$VAULT/claude-memory/projects" ] && [ ! -L "$VAULT/claude-memory/projects" ]
+}
+
+then_the_projects_symlink_under_the_vault_still_exists() {
+  [ -L "$VAULT/claude-memory/projects" ]
+}
+
+then_the_projects_directory_under_the_vault_is_not_removed() {
+  [ -d "$VAULT/claude-memory/projects" ]
+}
+
+then_the_sessions_directory_under_the_vault_is_preserved_byte_for_byte() {
+  [ -d "$VAULT/claude-memory/sessions" ] || return 1
+  assert_sessions_untouched
+}
+
+then_the_sessions_directory_under_the_vault_no_longer_exists() {
+  [ ! -e "$VAULT/claude-memory/sessions" ]
+}
+
+then_the_index_md_under_the_vault_is_preserved_byte_for_byte() {
+  [ -f "$VAULT/claude-memory/Index.md" ] || return 1
+  assert_sessions_untouched
+}
+
+then_the_index_md_under_the_vault_no_longer_exists() {
+  [ ! -e "$VAULT/claude-memory/Index.md" ]
+}
+
+then_the_stub_claude_was_invoked_with() {
+  local needle="${1:-}"
+  [ -s "$T_CLAUDE_LOG" ] || return 1
+  grep -qF -- "$needle" "$T_CLAUDE_LOG"
+}
+
+then_the_stub_claude_was_not_invoked() {
+  [ ! -s "$T_CLAUDE_LOG" ]
+}
+
+then_no_file_under_is_created() {
+  # Arg: "~/.claude/obsidian-memory"
+  [ ! -e "$HOME/.claude/obsidian-memory" ] || {
+    [ -z "$(find "$HOME/.claude/obsidian-memory" -mindepth 1 -print -quit 2>/dev/null)" ]
+  }
+}
+
+then_the_second_run_s_output_contains() {
+  local needle="${1:-}"
+  printf '%s' "$T_STDOUT" | grep -qF -- "$needle"
+}
+
+then_the_second_run_s_exit_code_is_0() {
+  [ "$T_RC" -eq 0 ]
+}

--- a/tests/helpers/scratch.bash
+++ b/tests/helpers/scratch.bash
@@ -74,3 +74,35 @@ assert_home_untouched() {
   fi
   return 0
 }
+
+# Snapshot + assertion pair for the distilled-sessions subtree under the
+# scratch vault. Used by teardown tests to prove that default / dry-run /
+# refusal / purge-cancelled paths never mutate the user's memory.
+_sessions_digest() {
+  local vault="$1"
+  [ -d "$vault/claude-memory" ] || return 0
+  ( cd "$vault" \
+    && find claude-memory/sessions claude-memory/Index.md \
+         \( -type f -o -type d \) -print0 2>/dev/null \
+       | LC_ALL=C sort -z \
+       | xargs -0 cksum 2>/dev/null \
+       | LC_ALL=C sort
+  )
+}
+
+snapshot_sessions() {
+  _SCRATCH_SESSIONS_DIGEST="$(_sessions_digest "$VAULT")"
+  export _SCRATCH_SESSIONS_DIGEST
+}
+
+assert_sessions_untouched() {
+  local current expected="${_SCRATCH_SESSIONS_DIGEST-}"
+  current="$(_sessions_digest "$VAULT")"
+  if [ "$current" != "$expected" ]; then
+    printf 'assert_sessions_untouched: sessions/ or Index.md digest changed\n' >&2
+    printf 'expected: %s\n' "$expected" >&2
+    printf 'actual:   %s\n' "$current" >&2
+    return 1
+  fi
+  return 0
+}

--- a/tests/integration/teardown.bats
+++ b/tests/integration/teardown.bats
@@ -1,0 +1,292 @@
+#!/usr/bin/env bats
+
+# tests/integration/teardown.bats — end-to-end coverage of vault-teardown.sh.
+#
+# Every scenario runs under the bats scratch harness (tests/helpers/scratch)
+# so $HOME is redirected to $BATS_TEST_TMPDIR/home and $VAULT is a disposable
+# scratch vault. teardown() calls assert_sessions_untouched on every test
+# except the purge-confirmed and idempotent-after-default cases — those
+# legitimately delete the sessions subtree.
+#
+# Matches the test matrix in specs/feature-add-obsidian-memory-teardown-skill/
+# design.md → Testing Strategy (17 rows).
+
+setup() {
+  load '../helpers/scratch'
+
+  TEARDOWN="$PLUGIN_ROOT/scripts/vault-teardown.sh"
+  export TEARDOWN
+
+  CONFIG="$HOME/.claude/obsidian-memory/config.json"
+  export CONFIG
+
+  mkdir -p "$HOME/.claude/obsidian-memory" "$HOME/.claude/projects"
+
+  _install_safe_path
+}
+
+teardown() {
+  if [ "${_SKIP_SESSIONS_ASSERT:-0}" != 1 ]; then
+    assert_sessions_untouched
+  fi
+}
+
+# Install a fresh PATH containing symlinks to every real executable plus a
+# stub claude that logs invocations to $T_CLAUDE_LOG.
+_install_safe_path() {
+  local bindir="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$bindir"
+
+  local d f name
+  local IFS_SAVED="$IFS"
+  IFS=':'
+  for d in $PATH; do
+    [ -d "$d" ] || continue
+    for f in "$d"/*; do
+      [ -x "$f" ] || continue
+      name="$(basename "$f")"
+      [ -e "$bindir/$name" ] && continue
+      ln -s "$f" "$bindir/$name" 2>/dev/null || true
+    done
+  done
+  IFS="$IFS_SAVED"
+
+  T_CLAUDE_LOG="$BATS_TEST_TMPDIR/claude.log"
+  export T_CLAUDE_LOG
+  : > "$T_CLAUDE_LOG"
+
+  _install_stub_claude succeed
+
+  PATH="$bindir"
+  export PATH
+}
+
+_install_stub_claude() {
+  local mode="${1:-succeed}"
+  local bindir="$BATS_TEST_TMPDIR/bin"
+  local rc
+  case "$mode" in
+    succeed) rc=0 ;;
+    fail)    rc=1 ;;
+    *) return 1 ;;
+  esac
+
+  rm -f "$bindir/claude"
+  cat > "$bindir/claude" <<CLAUDE
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$T_CLAUDE_LOG"
+exit $rc
+CLAUDE
+  chmod +x "$bindir/claude"
+}
+
+_healthy_install() {
+  local n="${1:-3}" i
+  cat > "$CONFIG" <<EOF
+{"vaultPath":"$VAULT","rag":{"enabled":true},"distill":{"enabled":true}}
+EOF
+  mkdir -p "$VAULT/claude-memory/sessions/proj"
+  ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+  printf '# Claude Memory Index\n\n## Sessions\n' > "$VAULT/claude-memory/Index.md"
+  for (( i = 1; i <= n; i++ )); do
+    printf 'note %d\n' "$i" > "$VAULT/claude-memory/sessions/proj/note-$i.md"
+  done
+  snapshot_sessions
+}
+
+# --- AC1: default teardown --------------------------------------------------
+
+@test "happy_default: default teardown removes config + symlink, preserves sessions" {
+  _healthy_install 3
+  run "$TEARDOWN"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"REMOVED"* ]]
+  [[ "$output" == *"PRESERVED"* ]]
+  [ ! -e "$CONFIG" ]
+  [ ! -e "$VAULT/claude-memory/projects" ]
+  [ -d "$VAULT/claude-memory/sessions" ]
+  [ -f "$VAULT/claude-memory/Index.md" ]
+}
+
+# --- AC2: --purge variants --------------------------------------------------
+
+@test "purge_yes: --purge with literal yes deletes sessions and Index.md" {
+  _healthy_install 5
+  _SKIP_SESSIONS_ASSERT=1
+  run bash -c "printf 'yes\n' | '$TEARDOWN' --purge"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Distilled notes deleted"* ]]
+  [ ! -e "$CONFIG" ]
+  [ ! -e "$VAULT/claude-memory/projects" ]
+  [ ! -e "$VAULT/claude-memory/sessions" ]
+  [ ! -e "$VAULT/claude-memory/Index.md" ]
+}
+
+@test "purge_y: --purge with 'y' cancels and preserves sessions" {
+  _healthy_install 5
+  run bash -c "printf 'y\n' | '$TEARDOWN' --purge"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"purge cancelled"* ]]
+  [ -d "$VAULT/claude-memory/sessions" ]
+  [ -f "$VAULT/claude-memory/Index.md" ]
+}
+
+@test "purge_cap_YES: --purge with 'YES' cancels and preserves sessions" {
+  _healthy_install 5
+  run bash -c "printf 'YES\n' | '$TEARDOWN' --purge"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"purge cancelled"* ]]
+  [ -d "$VAULT/claude-memory/sessions" ]
+  [ -f "$VAULT/claude-memory/Index.md" ]
+}
+
+@test "purge_empty: --purge with empty line cancels and preserves sessions" {
+  _healthy_install 5
+  run bash -c "printf '\n' | '$TEARDOWN' --purge"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"purge cancelled"* ]]
+  [ -d "$VAULT/claude-memory/sessions" ]
+  [ -f "$VAULT/claude-memory/Index.md" ]
+}
+
+@test "purge_eof: --purge with EOF on stdin cancels and preserves sessions" {
+  _healthy_install 5
+  run bash -c "'$TEARDOWN' --purge </dev/null"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"purge cancelled"* ]]
+  [ -d "$VAULT/claude-memory/sessions" ]
+  [ -f "$VAULT/claude-memory/Index.md" ]
+}
+
+# --- AC3: --unregister-mcp --------------------------------------------------
+
+@test "unregister_mcp_ok: --unregister-mcp invokes claude mcp remove" {
+  _healthy_install 3
+  _install_stub_claude succeed
+  : > "$T_CLAUDE_LOG"
+  run "$TEARDOWN" --unregister-mcp
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MCP"* ]]
+  grep -qF "mcp remove obsidian -s user" "$T_CLAUDE_LOG"
+  [ ! -e "$CONFIG" ]
+  [ ! -e "$VAULT/claude-memory/projects" ]
+}
+
+@test "unregister_mcp_fail: non-zero claude exit is non-fatal" {
+  _healthy_install 3
+  _install_stub_claude fail
+  : > "$T_CLAUDE_LOG"
+  run "$TEARDOWN" --unregister-mcp
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MCP"* ]]
+  [ ! -e "$CONFIG" ]
+  [ ! -e "$VAULT/claude-memory/projects" ]
+}
+
+# --- AC4: path-safety refusal -----------------------------------------------
+
+@test "refuse_no_claude_memory: vault has no claude-memory dir → REFUSED, nothing deleted" {
+  _healthy_install 3
+  rm -rf "$VAULT/claude-memory"
+  snapshot_sessions
+  run "$TEARDOWN"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"REFUSED"* ]]
+  [[ "$output" == *"/obsidian-memory:doctor"* ]]
+  [ -f "$CONFIG" ]
+}
+
+@test "refuse_projects_not_symlink: projects is a regular directory → REFUSED" {
+  _healthy_install 3
+  rm -f "$VAULT/claude-memory/projects"
+  mkdir -p "$VAULT/claude-memory/projects/sub"
+  printf 'marker\n' > "$VAULT/claude-memory/projects/keep.txt"
+  run "$TEARDOWN"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"REFUSED"* ]]
+  [[ "$output" == *"/obsidian-memory:doctor"* ]]
+  [ -f "$CONFIG" ]
+  [ -d "$VAULT/claude-memory/projects" ]
+}
+
+@test "refuse_projects_wrong_target: projects symlink points elsewhere → REFUSED" {
+  _healthy_install 3
+  rm -f "$VAULT/claude-memory/projects"
+  mkdir -p "$BATS_TEST_TMPDIR/unrelated"
+  ln -s "$BATS_TEST_TMPDIR/unrelated" "$VAULT/claude-memory/projects"
+  run "$TEARDOWN"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"REFUSED"* ]]
+  [[ "$output" == *"/obsidian-memory:doctor"* ]]
+  [ -f "$CONFIG" ]
+  [ -L "$VAULT/claude-memory/projects" ]
+}
+
+@test "refuse_vault_missing: configured vaultPath does not exist → REFUSED" {
+  cat > "$CONFIG" <<EOF
+{"vaultPath":"$BATS_TEST_TMPDIR/nope","rag":{"enabled":true},"distill":{"enabled":true}}
+EOF
+  snapshot_sessions
+  run "$TEARDOWN"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"REFUSED"* ]]
+  [[ "$output" == *"/obsidian-memory:doctor"* ]]
+  [ -f "$CONFIG" ]
+}
+
+# --- AC5: idempotency ------------------------------------------------------
+
+@test "idempotent_no_config: no config at all → nothing to do, exit 0" {
+  rm -rf "$HOME/.claude/obsidian-memory"
+  snapshot_sessions
+  run "$TEARDOWN"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to do"* ]]
+  [ ! -e "$CONFIG" ]
+}
+
+@test "idempotent_after_default: re-running after default teardown is a no-op" {
+  _healthy_install 3
+  _SKIP_SESSIONS_ASSERT=1
+  run "$TEARDOWN"
+  [ "$status" -eq 0 ]
+  run "$TEARDOWN"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nothing to do"* ]]
+}
+
+# --- AC6: --dry-run --------------------------------------------------------
+
+@test "dry_run_healthy: --dry-run prints plan and touches nothing" {
+  _healthy_install 4
+  run "$TEARDOWN" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WOULD REMOVE"* ]]
+  [[ "$output" == *"WOULD PRESERVE"* ]]
+  [ -f "$CONFIG" ]
+  [ -L "$VAULT/claude-memory/projects" ]
+  [ -d "$VAULT/claude-memory/sessions" ]
+  [ -f "$VAULT/claude-memory/Index.md" ]
+}
+
+@test "dry_run_purge: --dry-run --purge lists sessions under WOULD REMOVE without prompting" {
+  _healthy_install 4
+  run bash -c "'$TEARDOWN' --dry-run --purge </dev/null"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WOULD REMOVE"* ]]
+  [[ "$output" == *"$VAULT/claude-memory/sessions"* ]]
+  [[ "$output" != *"Type 'yes'"* ]]
+  [ -f "$CONFIG" ]
+  [ -L "$VAULT/claude-memory/projects" ]
+  [ -d "$VAULT/claude-memory/sessions" ]
+  [ -f "$VAULT/claude-memory/Index.md" ]
+}
+
+@test "dry_run_unregister: --dry-run --unregister-mcp does not invoke claude" {
+  _healthy_install 3
+  : > "$T_CLAUDE_LOG"
+  run "$TEARDOWN" --dry-run --unregister-mcp
+  [ "$status" -eq 0 ]
+  [ ! -s "$T_CLAUDE_LOG" ]
+  [ -f "$CONFIG" ]
+}

--- a/tests/run-bdd.sh
+++ b/tests/run-bdd.sh
@@ -37,6 +37,7 @@ _step_file_for() {
     feature-session-distillation-hook)                printf '%s' "$STEPS_DIR/distill.sh" ;;
     feature-manual-distill-skill)                     printf '%s' "$STEPS_DIR/manual-distill.sh" ;;
     feature-doctor-health-check-skill)                printf '%s' "$STEPS_DIR/doctor.sh" ;;
+    feature-add-obsidian-memory-teardown-skill)       printf '%s' "$STEPS_DIR/teardown.sh" ;;
     feature-set-up-bats-core-cucumber-shell-test-harness) printf '%s' "$STEPS_DIR/harness.sh" ;;
     example)                                          printf '%s' "$STEPS_DIR/example.sh" ;;
     *)


### PR DESCRIPTION
## Summary

- Adds `scripts/vault-teardown.sh`: a safety-gated shell script that removes the obsidian-memory install footprint (config, symlink) while preserving distilled session notes by default
- Adds `skills/teardown/SKILL.md`: thin skill wrapper that relays the script's output and exit code verbatim
- Adds integration tests (`tests/integration/teardown.bats`) covering 17 scenarios including path-safety refusals, `--purge` with typed-yes confirmation, `--dry-run`, and idempotent double-teardown

## Acceptance Criteria

From `specs/feature-add-obsidian-memory-teardown-skill/requirements.md`:

- [ ] AC1: Default teardown removes config and symlink, preserves distilled notes (sessions/ and Index.md untouched), exits 0
- [ ] AC2: `--purge` deletes distilled notes only after typed "yes" confirmation; any other input cancels and preserves sessions
- [ ] AC3: `--unregister-mcp` runs the inverse of setup's MCP registration; non-zero exit is non-fatal
- [ ] AC4: Teardown refuses to touch paths outside the recorded install footprint — detects mismatch and exits 1 with remediation hint
- [ ] AC5: Teardown is idempotent — running twice on a torn-down state reports "nothing to do" and exits 0
- [ ] AC6 (FR8): `--dry-run` prints what would be removed without touching anything; combined with `--purge` lists sessions without prompting

## Test Plan

From `specs/feature-add-obsidian-memory-teardown-skill/tasks.md` testing phase:

- [ ] Integration (bats): 17-test matrix in `tests/integration/teardown.bats` covering all flag combinations, path-safety refusals, purge confirmation variants, and dry-run
- [ ] BDD (Gherkin): scenarios in `specs/feature-add-obsidian-memory-teardown-skill/feature.gherkin` with step definitions in `tests/features/steps/teardown.sh`
- [ ] shellcheck: `scripts/vault-teardown.sh` and `tests/features/steps/teardown.sh` pass shellcheck

## Specs

- Requirements: `specs/feature-add-obsidian-memory-teardown-skill/requirements.md`
- Design: `specs/feature-add-obsidian-memory-teardown-skill/design.md`
- Tasks: `specs/feature-add-obsidian-memory-teardown-skill/tasks.md`

Closes #3