### PR TITLE
feat: add /obsidian-memory:toggle skill for rag/distill enable flags (#4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-memory",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Cross-session memory backed by an Obsidian vault. Retrieves relevant notes on every prompt and distills each session into a dated vault entry.",
   "author": {
     "name": "Rich Nunley",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to plugins in this marketplace are documented here. Format f
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-21
+
+### Added
+
+- `/obsidian-memory:toggle` skill — one-command toggle for `rag.enabled` and `distill.enabled` flags in `~/.claude/obsidian-memory/config.json`. Supports `toggle <feature> on|off`, `toggle <feature>` (flip), and `toggle status` (read-only). Writes are atomic via temp-file + `mv`. Closes #4.
+
 ## [0.2.0] - 2026-04-21
 
 ### Added

--- a/scripts/vault-toggle.sh
+++ b/scripts/vault-toggle.sh
@@ -21,7 +21,7 @@ TMP=""
 
 # shellcheck disable=SC2329  # invoked indirectly by the EXIT trap
 cleanup() {
-  [ -n "$TMP" ] && rm -f "$TMP" 2>/dev/null || true
+  [ -n "$TMP" ] && rm -f "$TMP" 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -104,10 +104,9 @@ ensure_preconditions() {
 cmd_status() {
   ensure_preconditions
   local rag distill
-  rag="$(read_flag rag)"
-  distill="$(read_flag distill)"
-  [ -n "$rag" ] || rag="true"
-  [ -n "$distill" ] || distill="true"
+  IFS=$'\t' read -r rag distill < <(
+    jq -r '[(.rag.enabled != false), (.distill.enabled != false)] | @tsv' "$CONFIG" 2>/dev/null
+  )
   printf 'rag.enabled: %s\n' "$rag"
   printf 'distill.enabled: %s\n' "$distill"
 }
@@ -139,7 +138,6 @@ cmd_flip() {
 
   local current new
   current="$(read_flag "$feature")"
-  [ -n "$current" ] || current="true"
   if [ "$current" = "true" ]; then new="false"; else new="true"; fi
 
   write_flag "$feature" "$new" || exit 1

--- a/scripts/vault-toggle.sh
+++ b/scripts/vault-toggle.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# vault-toggle.sh — flip rag.enabled / distill.enabled in config.json.
+#
+# User-invoked (unlike the silent hook scripts), so errors surface instead of
+# silently no-op'ing: missing config, unknown feature, unknown state alias, or
+# a failed write all exit non-zero with a descriptive ERROR: line on stderr.
+#
+# Mutating writes go through jq into a same-directory temp file followed by
+# mv — a SIGKILL between steps leaves the original config intact, and an
+# EXIT trap cleans any stray temp file.
+#
+# Exit codes:
+#   0 — success (status, successful mutation, "was already" no-op)
+#   1 — runtime error (missing config, missing jq, atomic-write failure)
+#   2 — bad usage (unknown feature, unknown state alias, too many args)
+
+set -u
+
+CONFIG="${HOME}/.claude/obsidian-memory/config.json"
+TMP=""
+
+# shellcheck disable=SC2329  # invoked indirectly by the EXIT trap
+cleanup() {
+  [ -n "$TMP" ] && rm -f "$TMP" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+log_err() {
+  printf 'ERROR: %s\n' "$*" >&2
+}
+
+usage_stderr() {
+  cat >&2 <<'USAGE'
+Usage:
+  vault-toggle.sh                        # print status for both flags
+  vault-toggle.sh status                 # same as above
+  vault-toggle.sh <feature>              # flip current value
+  vault-toggle.sh <feature> <state>      # set explicit value
+
+<feature> ::= rag | distill
+<state>   ::= on | off | true | false | 1 | 0 | yes | no   (case-insensitive)
+USAGE
+}
+
+# Map a state alias to "true" / "false". Anything else → empty output, exit 1.
+normalize_state() {
+  local raw="$1"
+  local lower
+  lower="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$lower" in
+    on|true|1|yes) printf 'true' ;;
+    off|false|0|no) printf 'false' ;;
+    *) return 1 ;;
+  esac
+}
+
+# Read .<feature>.enabled from the config, normalising unset/null to "true".
+# Used for status output and for computing the flipped value in cmd_flip.
+read_flag() {
+  local feature="$1"
+  jq -r "(.${feature}.enabled != false) | tostring" "$CONFIG" 2>/dev/null
+}
+
+# Raw read: "true" / "false" if explicitly set, empty string if unset/null.
+# Used by cmd_set to decide whether the mutation is a no-op. An unset flag is
+# NOT "already in state" — the user expects an explicit write so the stanza
+# lands in the config (design.md → Risks → "unset ambiguity").
+read_flag_raw() {
+  local feature="$1"
+  jq -r ".${feature}.enabled? // empty | tostring" "$CONFIG" 2>/dev/null
+}
+
+# Atomically rewrite the config with .<feature>.enabled = <bool>.
+write_flag() {
+  local feature="$1" value="$2"
+  TMP="$CONFIG.tmp.$$"
+  if ! jq --indent 2 --argjson v "$value" ".${feature}.enabled = \$v" "$CONFIG" > "$TMP"; then
+    log_err "failed to write config"
+    return 1
+  fi
+  if ! mv "$TMP" "$CONFIG"; then
+    log_err "failed to write config"
+    return 1
+  fi
+  TMP=""
+  return 0
+}
+
+ensure_preconditions() {
+  if ! command -v jq >/dev/null 2>&1; then
+    log_err "jq missing — install jq (brew install jq)"
+    exit 1
+  fi
+  if [ ! -f "$CONFIG" ]; then
+    log_err "config not found — run /obsidian-memory:setup <vault> first"
+    exit 1
+  fi
+  if [ ! -r "$CONFIG" ]; then
+    log_err "config not readable at $CONFIG"
+    exit 1
+  fi
+}
+
+cmd_status() {
+  ensure_preconditions
+  local rag distill
+  rag="$(read_flag rag)"
+  distill="$(read_flag distill)"
+  [ -n "$rag" ] || rag="true"
+  [ -n "$distill" ] || distill="true"
+  printf 'rag.enabled: %s\n' "$rag"
+  printf 'distill.enabled: %s\n' "$distill"
+}
+
+cmd_set() {
+  local feature="$1" new_value="$2"
+  ensure_preconditions
+
+  local raw
+  raw="$(read_flag_raw "$feature")"
+
+  if [ "$raw" = "$new_value" ]; then
+    printf '%s.enabled was already %s\n' "$feature" "$raw"
+    return 0
+  fi
+
+  write_flag "$feature" "$new_value" || exit 1
+
+  # Report the effective prior value (unset → "true") so the output always
+  # shows a concrete boolean rather than an empty prev field.
+  local prev="$raw"
+  [ -n "$prev" ] || prev="true"
+  printf '%s.enabled: %s -> %s\n' "$feature" "$prev" "$new_value"
+}
+
+cmd_flip() {
+  local feature="$1"
+  ensure_preconditions
+
+  local current new
+  current="$(read_flag "$feature")"
+  [ -n "$current" ] || current="true"
+  if [ "$current" = "true" ]; then new="false"; else new="true"; fi
+
+  write_flag "$feature" "$new" || exit 1
+  printf '%s.enabled: %s -> %s\n' "$feature" "$current" "$new"
+}
+
+main() {
+  if [ "$#" -gt 2 ]; then
+    usage_stderr
+    exit 2
+  fi
+
+  if [ "$#" -eq 0 ]; then
+    cmd_status
+    exit 0
+  fi
+
+  local first="$1"
+  if [ "$first" = "status" ] && [ "$#" -eq 1 ]; then
+    cmd_status
+    exit 0
+  fi
+
+  case "$first" in
+    rag|distill) ;;
+    -h|--help) usage_stderr; exit 0 ;;
+    *)
+      log_err "unknown feature '$first' — allowed: rag, distill"
+      exit 2
+      ;;
+  esac
+
+  if [ "$#" -eq 1 ]; then
+    cmd_flip "$first"
+    exit 0
+  fi
+
+  local state_raw="$2" state_norm
+  if ! state_norm="$(normalize_state "$state_raw")"; then
+    log_err "unknown state '$state_raw' — allowed: on, off, true, false, 1, 0, yes, no"
+    exit 2
+  fi
+
+  cmd_set "$first" "$state_norm"
+  exit 0
+}
+
+main "$@"

--- a/scripts/vault-toggle.sh
+++ b/scripts/vault-toggle.sh
@@ -19,15 +19,16 @@ set -u
 CONFIG="${HOME}/.claude/obsidian-memory/config.json"
 TMP=""
 
+log_err() {
+  printf 'ERROR: %s\n' "$*" >&2
+}
+
 # shellcheck disable=SC2329  # invoked indirectly by the EXIT trap
 cleanup() {
   [ -n "$TMP" ] && rm -f "$TMP" 2>/dev/null
 }
 trap cleanup EXIT
-
-log_err() {
-  printf 'ERROR: %s\n' "$*" >&2
-}
+trap 'log_err "failed at line $LINENO"; exit 1' ERR
 
 usage_stderr() {
   cat >&2 <<'USAGE'
@@ -54,36 +55,27 @@ normalize_state() {
   esac
 }
 
-# Read .<feature>.enabled from the config, normalising unset/null to "true".
-# Used for status output and for computing the flipped value in cmd_flip.
+# Raw read: "true" / "false" if explicitly set, empty string if unset/null.
+# An unset flag is deliberately NOT treated as "already in state" — the user
+# expects an explicit write so the stanza lands in the config (design.md →
+# Risks → "unset ambiguity"). Callers normalise empty → "true" for reporting.
+# jq's `//` operator fires on both null and false, so we test for null
+# explicitly to distinguish "unset" from "set to false".
 read_flag() {
   local feature="$1"
-  jq -r "(.${feature}.enabled != false) | tostring" "$CONFIG" 2>/dev/null
-}
-
-# Raw read: "true" / "false" if explicitly set, empty string if unset/null.
-# Used by cmd_set to decide whether the mutation is a no-op. An unset flag is
-# NOT "already in state" — the user expects an explicit write so the stanza
-# lands in the config (design.md → Risks → "unset ambiguity").
-read_flag_raw() {
-  local feature="$1"
-  jq -r ".${feature}.enabled? // empty | tostring" "$CONFIG" 2>/dev/null
+  jq -r ".${feature}.enabled? as \$v | if \$v == null then \"\" else \$v | tostring end" "$CONFIG" 2>/dev/null
 }
 
 # Atomically rewrite the config with .<feature>.enabled = <bool>.
 write_flag() {
   local feature="$1" value="$2"
   TMP="$CONFIG.tmp.$$"
-  if ! jq --indent 2 --argjson v "$value" ".${feature}.enabled = \$v" "$CONFIG" > "$TMP"; then
-    log_err "failed to write config"
-    return 1
-  fi
-  if ! mv "$TMP" "$CONFIG"; then
+  if ! jq --indent 2 --argjson v "$value" ".${feature}.enabled = \$v" "$CONFIG" > "$TMP" \
+     || ! mv "$TMP" "$CONFIG"; then
     log_err "failed to write config"
     return 1
   fi
   TMP=""
-  return 0
 }
 
 ensure_preconditions() {
@@ -116,7 +108,7 @@ cmd_set() {
   ensure_preconditions
 
   local raw
-  raw="$(read_flag_raw "$feature")"
+  raw="$(read_flag "$feature")"
 
   if [ "$raw" = "$new_value" ]; then
     printf '%s.enabled was already %s\n' "$feature" "$raw"
@@ -125,8 +117,6 @@ cmd_set() {
 
   write_flag "$feature" "$new_value" || exit 1
 
-  # Report the effective prior value (unset → "true") so the output always
-  # shows a concrete boolean rather than an empty prev field.
   local prev="$raw"
   [ -n "$prev" ] || prev="true"
   printf '%s.enabled: %s -> %s\n' "$feature" "$prev" "$new_value"
@@ -138,6 +128,7 @@ cmd_flip() {
 
   local current new
   current="$(read_flag "$feature")"
+  [ -n "$current" ] || current="true"
   if [ "$current" = "true" ]; then new="false"; else new="true"; fi
 
   write_flag "$feature" "$new" || exit 1

--- a/scripts/vault-toggle.sh
+++ b/scripts/vault-toggle.sh
@@ -94,7 +94,6 @@ ensure_preconditions() {
 }
 
 cmd_status() {
-  ensure_preconditions
   local rag distill
   IFS=$'\t' read -r rag distill < <(
     jq -r '[(.rag.enabled != false), (.distill.enabled != false)] | @tsv' "$CONFIG" 2>/dev/null
@@ -105,8 +104,6 @@ cmd_status() {
 
 cmd_set() {
   local feature="$1" new_value="$2"
-  ensure_preconditions
-
   local raw
   raw="$(read_flag "$feature")"
 
@@ -124,8 +121,6 @@ cmd_set() {
 
 cmd_flip() {
   local feature="$1"
-  ensure_preconditions
-
   local current new
   current="$(read_flag "$feature")"
   [ -n "$current" ] || current="true"
@@ -140,6 +135,8 @@ main() {
     usage_stderr
     exit 2
   fi
+
+  ensure_preconditions
 
   if [ "$#" -eq 0 ]; then
     cmd_status

--- a/skills/toggle/SKILL.md
+++ b/skills/toggle/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: toggle
+description: Flip rag.enabled / distill.enabled in obsidian-memory's config without hand-editing JSON. Use when the user says "disable rag", "enable distill", "turn off obsidian memory hook", "toggle rag", "toggle distill", "stop distilling sessions", "pause obsidian memory", or invokes /obsidian-memory:toggle.
+argument-hint: [<feature> [<state>]]
+allowed-tools: Bash, Read
+model: sonnet
+effort: low
+---
+
+# obsidian-memory: toggle
+
+Flip the `rag.enabled` / `distill.enabled` booleans in `~/.claude/obsidian-memory/config.json` with a single command, preserving every other key in the file. Toggle is a **thin relayer**: every code path — arg parsing, feature whitelist, atomic write, exit code selection — lives in `scripts/vault-toggle.sh`, which this skill invokes once and reports back verbatim. The usual loop of "open the config, flip a boolean, save" collapses into one invocation the user can type while they're already in the middle of debugging a hook.
+
+## When to Use
+
+- The user wants to disable RAG injection for a session (`/obsidian-memory:toggle rag off`).
+- Distillation is misbehaving and the user wants to stop writing to the vault while they investigate (`/obsidian-memory:toggle distill off`).
+- The user wants to confirm whether a surprising behavior originates from obsidian-memory by temporarily turning a hook off, then on again.
+- `/obsidian-memory:doctor` reported `rag.enabled` or `distill.enabled` as `FAIL` and its remediation hint pointed here.
+- The user asks for the current state of both flags without changing anything (`/obsidian-memory:toggle` or `/obsidian-memory:toggle status`).
+
+## When NOT to Use
+
+- **To write the config from scratch.** Toggle requires a config produced by `/obsidian-memory:setup`; a missing config is a clean error with a setup hint, not a silent create.
+- **To change any key other than `rag.enabled` or `distill.enabled`.** The feature whitelist is hard-coded to those two. Editing `vaultPath` or any other key is still a hand-edit job (or a new skill).
+- **To skip distillation for one specific session.** If the user only wants to opt out of a single distill, `/obsidian-memory:distill-session` is the alternate manual entry point — flipping `distill.enabled` is heavier than needed.
+- **To uninstall the plugin's footprint.** Removing the config and the `<vault>/claude-memory/projects` symlink is `/obsidian-memory:teardown`'s job.
+
+## Invocation
+
+```
+/obsidian-memory:toggle                      # status — prints both flags, mutates nothing
+/obsidian-memory:toggle status               # same as above, explicit
+/obsidian-memory:toggle rag                  # flip current rag.enabled
+/obsidian-memory:toggle rag off              # set rag.enabled = false
+/obsidian-memory:toggle distill on           # set distill.enabled = true
+```
+
+`<feature>` is exactly `rag` or `distill`. `<state>` is case-insensitive and accepts the aliases `on` / `off`, `true` / `false`, `1` / `0`, `yes` / `no` — this way the user's muscle memory works whether they think in CLI-isms (`on`/`off`) or JSON-isms (`true`/`false`).
+
+## Behavior
+
+1. Invoke `"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/obsidian-memory}/scripts/vault-toggle.sh" "$@"` so every argument passes through verbatim. Do not re-parse the arguments and do not re-run the script.
+2. Relay the script's stdout and exit code directly. If the script exits non-zero, summarize the specific reason in one line (e.g., "toggle failed: config not found — run `/obsidian-memory:setup <vault>` first") so the user does not have to re-read the full output, but never substitute your own interpretation for the script's message.
+3. On a successful mutation the script prints `<feature>.enabled: <prev> -> <new>` on stdout. On an already-in-state call it prints `<feature>.enabled was already <value>` — this is still a success and exits 0. On a status read it prints both flags on two lines.
+
+All logic — argument parsing, feature whitelist, alias resolution, atomic write, "was already" no-op detection — lives in `scripts/vault-toggle.sh`. Keeping the SKILL body free of logic is what lets the bats and cucumber-shell tests exercise every path deterministically without a live Claude session.
+
+## Exit Code Contract
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Success — includes a status read, a successful mutation, and the "was already in that state" no-op. |
+| `1` | Runtime error — config missing, config unreadable, `jq` missing, or the atomic write failed. The config on disk is unchanged. |
+| `2` | Bad usage — unknown feature, unknown state alias, or too many arguments. No read or write was attempted. |
+
+The first line of stderr on any error always starts with the literal `ERROR:` prefix, which makes the output grep-friendly for anyone scripting around it.
+
+## Error handling
+
+- **Missing config** (`~/.claude/obsidian-memory/config.json` does not exist): the script prints `ERROR: config not found — run /obsidian-memory:setup <vault> first` to stderr and exits 1. Nothing is created under `~/.claude/obsidian-memory/` — re-running `/obsidian-memory:setup` is the only way forward.
+- **Missing `jq`**: exits 1 with an install hint (`brew install jq`). Toggle will not attempt a write without `jq` because the atomic-write guarantee depends on it.
+- **Unknown feature or state alias**: exits 2 with a usage line naming the allowed values. The config is untouched (neither read for content nor rewritten).
+- **Failed write** (rare — out of disk, permissions, or a concurrent process holding the path): the atomic-write idiom guarantees the original config is never truncated or partially overwritten. The script exits 1; an `EXIT` trap clears any stray `.tmp.$$` artifact from the config directory.
+
+## Idempotency
+
+Toggle is idempotent by construction:
+
+- Running `/obsidian-memory:toggle rag on` against a config where `rag.enabled` is already `true` is a no-op — the script prints `rag.enabled was already true` and exits 0 **without rewriting the file** (so `mtime` and inode are preserved; downstream tools watching the config for changes stay quiet).
+- `/obsidian-memory:toggle status` and the no-arg invocation never write, so they're safe to run in a loop (e.g., from a `watch` command or a health check).
+- The mutation path writes to a temp file in the same directory as the config, then `mv`s it into place — an interrupted toggle (up to and including SIGKILL between the write and the rename) leaves the original config intact rather than corrupted.
+
+## Related skills
+
+- `/obsidian-memory:setup` writes the initial `~/.claude/obsidian-memory/config.json` that toggle reads and mutates. Toggle's "config not found" error points the user back to setup; there is no auto-creation path.
+- `/obsidian-memory:doctor` diagnoses the install read-only. When its `rag_enabled` or `distill_enabled` probe reports `FAIL`, its remediation hint is exactly `run /obsidian-memory:toggle <feature> on` — the two skills are deliberately wired together.
+- `/obsidian-memory:distill-session` manually checkpoints the newest transcript. If the user only wants to skip distilling one specific session rather than disable the hook for every future session, running `distill-session` against the desired session (or simply not running it) is lighter than flipping the global flag.

--- a/specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/design.md
+++ b/specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/design.md
@@ -1,0 +1,261 @@
+# Design: Toggle Skill for rag/distill Enable Flags
+
+**Issues**: #4
+**Date**: 2026-04-21
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## Overview
+
+The toggle skill is a thin user-facing wrapper around a single shell script that reads and writes `~/.claude/obsidian-memory/config.json`. The skill itself (`skills/toggle/SKILL.md`) carries only enough Markdown to explain the command and its flags; all behavior — arg parsing, whitelist enforcement, atomic write — lives in `scripts/vault-toggle.sh`. This split follows the pattern already used by `skills/doctor/` → `scripts/vault-doctor.sh` and `skills/teardown/` → `scripts/vault-teardown.sh`, keeping every code path deterministically testable under `bats` without a live Claude session.
+
+Unlike hook scripts, `vault-toggle.sh` is user-invoked and must **surface errors**: a missing config, an unknown feature, or a failed write are all non-zero exits with diagnostic stderr. This is the same stance `vault-doctor.sh` takes and the opposite of the hook scripts' silent-failure contract — the user invoked toggle expecting feedback. Accordingly, the script does **not** source `_common.sh::om_load_config`, which would mask those errors by exiting 0 (see Alternatives Considered → Option C).
+
+Writes go through `jq --indent 2` into a same-directory temp file followed by `mv` — the standard atomic-write idiom on a single filesystem. The config is never truncated or opened `O_TRUNC` in place; a SIGKILL between `jq` and `mv` leaves the original config intact, and the temp file is cleaned up by an `EXIT` trap so failed runs never leave `.tmp` droppings.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  User invokes /obsidian-memory:toggle [<feature> [<state>]]│
+└────────────────────────┬───────────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│  skills/toggle/SKILL.md                                    │
+│   - documents command, flags, exit codes, examples         │
+│   - instructs Claude to run scripts/vault-toggle.sh "$@"   │
+│   - relays exit code + stdout/stderr verbatim              │
+└────────────────────────┬───────────────────────────────────┘
+                         ▼
+┌────────────────────────────────────────────────────────────┐
+│  scripts/vault-toggle.sh                                   │
+│   - parse argv (0, 1, or 2 positional args)                │
+│   - enforce feature whitelist (rag | distill)              │
+│   - dispatch: status | show-then-flip | set-explicit       │
+│   - atomic write via temp file + mv                        │
+│   - exit 0 on success; 1 on user/config error; 2 on bad    │
+│     usage                                                  │
+└──────────┬─────────────────────────────────────────────────┘
+           │   READ + WRITE (single file)
+           ▼
+┌────────────────────────────────────────────────────────────┐
+│  ~/.claude/obsidian-memory/config.json                     │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+```
+1. SKILL.md receives invocation → shells out to scripts/vault-toggle.sh "$@"
+2. vault-toggle.sh:
+   a. Parse argv into (feature, state) tuple.
+      - 0 args OR first arg == "status"  → mode = status
+      - 1 arg (feature only)             → mode = flip
+      - 2 args (feature + state)         → mode = set
+   b. Validate feature ∈ {rag, distill}; any other value → usage + exit 2.
+   c. Validate state against alias table (mode=set only); unknown → usage + exit 2.
+   d. Verify config exists and is readable; else ERROR + exit 1.
+   e. For mode=status: read both flags via jq; print; exit 0.
+   f. For mode=flip: read current value; compute inverse; fall through to write.
+   g. For mode=set: if new value equals current → print "was already" + exit 0.
+   h. Write: jq rewrite to "$CONFIG.tmp.$$"; mv to "$CONFIG"; print prev -> new.
+   i. EXIT trap removes any leftover "$CONFIG.tmp.$$" on failure.
+3. Exit code propagates through the skill → user.
+```
+
+### Layer Responsibilities
+
+Per `steering/structure.md`:
+
+| Layer | Role in this feature |
+|-------|----------------------|
+| Skill (`skills/toggle/SKILL.md`) | User entry point; declarative. No logic. |
+| Script (`scripts/vault-toggle.sh`) | All logic. Reads argv, reads/writes config, formats output, chooses exit code. |
+| Config file (`~/.claude/obsidian-memory/config.json`) | The only mutable state. Written atomically; every non-touched key preserved. |
+
+---
+
+## API / Interface Changes
+
+### New: `scripts/vault-toggle.sh`
+
+Command-line interface:
+
+```
+vault-toggle.sh                     # status, shorthand
+vault-toggle.sh status              # status, explicit
+vault-toggle.sh <feature>           # flip current value
+vault-toggle.sh <feature> <state>   # set explicit
+
+<feature> ::= rag | distill
+<state>   ::= on | off | true | false | 1 | 0 | yes | no   (case-insensitive)
+```
+
+Exit codes:
+
+| Exit code | Meaning |
+|-----------|---------|
+| 0 | Success — includes status, successful mutation, and the "was already" no-op. |
+| 1 | Runtime error — config missing, config unreadable, `jq` missing, atomic-write failure. |
+| 2 | Bad usage — unknown feature, unknown state alias, too many args. |
+
+Stdout (success):
+
+```
+# status / shorthand
+rag.enabled: true
+distill.enabled: false
+
+# mutation
+rag.enabled: true -> false
+
+# already in state
+rag.enabled was already true
+```
+
+Stderr (error, first line always `ERROR:` for machine parsing):
+
+```
+ERROR: config not found — run /obsidian-memory:setup <vault> first
+ERROR: unknown feature 'foobar' — allowed: rag, distill
+ERROR: unknown state 'maybe' — allowed: on, off, true, false, 1, 0, yes, no
+ERROR: jq missing — install jq (brew install jq)
+ERROR: failed to write config
+```
+
+### New: `skills/toggle/SKILL.md`
+
+Skill frontmatter follows the convention used by `skills/doctor/SKILL.md`:
+
+```markdown
+---
+name: toggle
+description: Flip rag.enabled / distill.enabled in obsidian-memory's config without hand-editing JSON. Use when the user says "disable rag", "enable distill", "turn off obsidian memory hook", "toggle rag", or invokes /obsidian-memory:toggle.
+argument-hint: [<feature> [<state>]]
+allowed-tools: Bash, Read
+model: sonnet
+effort: low
+---
+```
+
+Body covers: When to Use, When NOT to Use, Invocation, Behavior (relay only), Exit Code Contract, Related skills. Mirrors the `doctor` SKILL body style so consumers see consistent structure across the plugin's skills.
+
+---
+
+## Database / Storage Changes
+
+No schema change. The config file already has `rag.enabled` and `distill.enabled` booleans; toggle mutates them in place.
+
+Key-preservation rules:
+
+- `jq --indent 2 '.<feature>.enabled = <bool>'` writes only the target key.
+- Every sibling and nested key — `vaultPath`, any user-added `customFoo`, future additions — round-trips unchanged because `jq` reads the whole document and re-emits it.
+- Key ordering is preserved in practice (jq preserves insertion order); this is not part of the contract but makes diffs clean.
+
+---
+
+## State Management
+
+Not applicable — this is a one-shot CLI. No in-memory state outlives the script invocation.
+
+---
+
+## UI Components
+
+Not applicable — no UI.
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Pros | Cons | Decision |
+|--------|-------------|------|------|----------|
+| **A: Inline everything in SKILL.md** | Put arg parsing, jq calls, and mv logic in the skill body so Claude executes them step by step. | No new script file; matches smaller skills. | Not unit-testable with bats. Every test would need a live Claude session. Debugging becomes trial-and-error. | Rejected. |
+| **B: Reuse `_common.sh::om_load_config`** | Source the shared config loader used by the hook scripts. | DRY; fewer code paths. | `om_load_config` exits 0 on any failure (missing config, missing jq, disabled flag) — that is correct for silent hooks but masks exactly the errors toggle must surface. Calling it would break AC5 (missing config error), AC4 (unknown-feature error), and the doctor cross-reference. | Rejected. Toggle reads the config directly, matching `vault-doctor.sh`'s stance for the same reason. |
+| **C: In-place truncate (`> "$CONFIG"`)** | Write new JSON via `jq ... > "$CONFIG"`. | Simpler; one fewer step. | Breaks AC6 — shell redirection truncates the target *before* `jq` writes. A SIGKILL between truncate and write leaves the config empty. Fails the atomic-write contract. | Rejected. |
+| **D: Write to temp file, then `mv`** | Render to `$CONFIG.tmp.$$`, then `mv` over the original. | Atomic on a single filesystem (POSIX guarantee); `jq` never touches the live config until success; EXIT trap cleans temp droppings. | One extra step. | **Selected.** |
+| **E: `cp` + in-place edit** | `cp config.json config.json.bak`, edit, commit on success. | Keeps a visible backup the user can inspect. | Backup accumulates across runs or leaves stale files after crashes. Does not solve atomicity (the edit itself can still be partial). The user already has git + Obsidian Sync for history. | Rejected. |
+
+---
+
+## Security Considerations
+
+- **Authentication**: None. Local CLI tool.
+- **Authorization**: Writes only `~/.claude/obsidian-memory/config.json`. No path from user input is ever used as a filesystem target — the only configurable path comes from `$HOME`.
+- **Input Validation**: All argv is validated against hard-coded whitelists (`rag`/`distill`, alias table). Unknown values fail with exit 2 *before* any jq call — no unsanitized input reaches a subprocess.
+- **Data Sanitization**: `jq` quotes values safely by construction; the script never interpolates user strings into `jq` filter source. The filter is a fixed template (`.rag.enabled = $v` / `.distill.enabled = $v`) and the boolean is passed via `--argjson` so jq parses it as a JSON literal.
+- **Sensitive Data**: Config contains no secrets.
+- **Filesystem safety**: Temp file lives in the same directory as `$CONFIG` (required for `mv` atomicity on a single FS) and its name is deterministic (`$CONFIG.tmp.$$`) so an `EXIT` trap can always find and remove it.
+
+---
+
+## Performance Considerations
+
+- **Caching**: None. One jq read + at most one jq write per invocation. The config is small (≤ 1 KB typical).
+- **Pagination**: N/A.
+- **Lazy Loading**: N/A.
+- **Indexing**: N/A.
+
+Expected wall time: single-digit ms for status, ~20–30 ms for a mutating run on a warm filesystem (bounded by two small `jq` invocations).
+
+---
+
+## Testing Strategy
+
+| Layer | Type | Coverage |
+|-------|------|----------|
+| Script (`vault-toggle.sh`) | bats integration (`tests/integration/toggle.bats`) | Every dispatch path: status, status-shorthand, explicit on, explicit off, flip from true, flip from false, already-in-state, unknown feature, unknown state alias, missing config, jq missing, atomic write survives SIGKILL simulation, key preservation with extra user keys, key preservation when the feature stanza is missing entirely. |
+| Skill (`skills/toggle/SKILL.md`) | Gate sweep (`tests/integration/gate_sweep.bats` — already in place) | Frontmatter validity, description string triggers correctly, allowed-tools matches intent. Adding a new skill extends the existing sweep; no per-skill bats is needed for the Markdown. |
+| BDD | cucumber-shell (`specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/feature.gherkin` + `tests/features/steps/toggle.sh`) | Every AC from `requirements.md`, with AC8 as a Scenario Outline over the alias table. |
+| Static | `shellcheck scripts/vault-toggle.sh` | Exit 0. |
+
+Tests run under the existing `tests/helpers/scratch.bash` harness: each scenario gets a scratch `$HOME` rooted at `$BATS_TEST_TMPDIR/home`, a fresh scratch config is written in the Given step, and assertions read the post-run config back from that scratch location. `assert_home_untouched` (already part of the harness) is called in teardown to prove the real `~/.claude/obsidian-memory/` was never mutated.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Atomic-write assumption fails on an exotic FS (e.g., fuse-mounted vault) | Low | Low — config lives under `~/.claude`, not the vault | Config path is under `$HOME/.claude/obsidian-memory/`, always on the same local FS as the temp file (which shares the directory). This is the same assumption every other script in the plugin makes. |
+| `jq` version skew between macOS default (often < 1.6) and Linux CI | Low | Medium | Steering doc requires `jq ≥ 1.6`. `--argjson` is available from 1.5+. We probe jq presence and exit 1 with a brew hint if missing. |
+| User runs toggle against a config with a missing feature stanza (e.g., older setup wrote only `rag`, never `distill`) | Medium | Low | `jq` treats `.distill.enabled` on a missing `distill` object as `null`. The read normalizes `null` → unset. The write uses `.distill.enabled = <bool>` which jq auto-creates the parent object. Unit test covers this. |
+| SIGKILL between temp-file creation and `mv` leaves temp droppings | Low | Very low | `trap 'rm -f "$TMP" 2>/dev/null' EXIT` at script top. SIGKILL bypasses traps by definition, but the droppings are harmless and have a predictable `.tmp.$$` suffix — next successful run does not collide because `$$` is unique per PID. |
+| "already in state" is ambiguous when the flag is unset (`null`) | Low | Low | Read normalizes unset → `true` (matches `_common.sh` semantics used by the hooks). Status prints the effective value, not the raw `null`. A `toggle rag on` against an unset-but-true-by-default flag writes it explicitly. AC7 covers the explicit-write case; an explicit scenario in BDD covers the unset case. |
+
+---
+
+## Open Questions
+
+None. All behavioral edge cases are pinned in requirements; all implementation decisions are captured above.
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #4 | 2026-04-21 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to TASKS phase:
+
+- [x] Architecture follows existing project patterns (per `structure.md`) — mirrors `skills/doctor/` and `skills/teardown/`
+- [x] All API/interface changes documented with schemas (CLI grammar, exit codes, stdout/stderr formats)
+- [x] Database/storage changes planned with migrations (no schema change; key-preservation rules documented)
+- [x] State management approach is clear (stateless one-shot)
+- [x] UI components and hierarchy defined (N/A — CLI only)
+- [x] Security considerations addressed
+- [x] Performance impact analyzed
+- [x] Testing strategy defined
+- [x] Alternatives were considered and documented
+- [x] Risks identified with mitigations

--- a/specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/feature.gherkin
+++ b/specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/feature.gherkin
@@ -1,0 +1,121 @@
+# File: specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/feature.gherkin
+#
+# Generated from: specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/requirements.md
+# Issue: #4
+
+Feature: Toggle Skill for rag/distill Enable Flags
+  As a Claude Code + Obsidian user troubleshooting a hook or temporarily stepping out of RAG
+  I want a one-command way to flip rag.enabled / distill.enabled
+  So that I do not have to hand-edit ~/.claude/obsidian-memory/config.json every time
+
+  Background:
+    Given obsidian-memory is installed at "$PLUGIN_ROOT"
+
+  # --- AC1: Explicit enable flips and reports prior -> new ---
+
+  Scenario: Explicit "off" flips rag.enabled from true to false
+    Given a config at "$HOME/.claude/obsidian-memory/config.json" with "rag.enabled" set to true
+    When  the user runs "vault-toggle.sh rag off"
+    Then  the exit code is 0
+    And   stdout contains "rag.enabled: true -> false"
+    And   the config at "$HOME/.claude/obsidian-memory/config.json" has "rag.enabled" set to false
+
+  # --- AC2: Flip without explicit state ---
+
+  Scenario: Toggle without an explicit state flips the current value
+    Given a config at "$HOME/.claude/obsidian-memory/config.json" with "distill.enabled" set to false
+    When  the user runs "vault-toggle.sh distill"
+    Then  the exit code is 0
+    And   stdout contains "distill.enabled: false -> true"
+    And   the config has "distill.enabled" set to true
+
+  # --- AC3: Status read-out is read-only ---
+
+  Scenario: Status prints both flags and does not mutate the config
+    Given a config with "rag.enabled" true and "distill.enabled" false
+    And   a snapshot of the config file's mtime and inode
+    When  the user runs "vault-toggle.sh status"
+    Then  the exit code is 0
+    And   stdout contains "rag.enabled: true"
+    And   stdout contains "distill.enabled: false"
+    And   the config file's mtime and inode match the snapshot
+
+  Scenario: No-arg invocation is equivalent to status
+    Given a config with "rag.enabled" true and "distill.enabled" true
+    And   a snapshot of the config file's mtime and inode
+    When  the user runs "vault-toggle.sh"
+    Then  the exit code is 0
+    And   stdout contains "rag.enabled: true"
+    And   stdout contains "distill.enabled: true"
+    And   the config file's mtime and inode match the snapshot
+
+  # --- AC4: Unknown feature errors cleanly ---
+
+  Scenario: Unknown feature name exits non-zero and does not mutate the config
+    Given a config with "rag.enabled" true and "distill.enabled" true
+    And   a snapshot of the config file's mtime and inode
+    When  the user runs "vault-toggle.sh foobar on"
+    Then  the exit code is 2
+    And   stderr contains "ERROR: unknown feature 'foobar'"
+    And   stderr contains "allowed: rag, distill"
+    And   the config file's mtime and inode match the snapshot
+
+  # --- AC5: Missing config is a clean error ---
+
+  Scenario: Missing config file reports a setup hint and exits non-zero
+    Given there is no config file at "$HOME/.claude/obsidian-memory/config.json"
+    When  the user runs "vault-toggle.sh rag on"
+    Then  the exit code is 1
+    And   stderr contains "ERROR: config not found"
+    And   stderr contains "/obsidian-memory:setup"
+    And   no file exists at "$HOME/.claude/obsidian-memory/config.json"
+
+  # --- AC6: Atomic writes ---
+
+  Scenario: Atomic write — original config survives a failed mv
+    Given a config at "$HOME/.claude/obsidian-memory/config.json" with "rag.enabled" set to true
+    And   the config contains an unrelated user key "customFoo" set to 42
+    And   a "mv" stub on PATH that always exits non-zero
+    When  the user runs "vault-toggle.sh rag off"
+    Then  the exit code is 1
+    And   the config at "$HOME/.claude/obsidian-memory/config.json" still has "rag.enabled" set to true
+    And   the config still has "customFoo" set to 42
+    And   no ".tmp" artifact remains in "$HOME/.claude/obsidian-memory/"
+
+  Scenario: Successful mutation preserves every unrelated key byte-for-byte
+    Given a config at "$HOME/.claude/obsidian-memory/config.json" with "rag.enabled" set to true
+    And   the config contains an unrelated user key "customFoo" set to 42
+    When  the user runs "vault-toggle.sh rag off"
+    Then  the exit code is 0
+    And   the config still has "customFoo" set to 42
+    And   the config uses 2-space indentation
+    And   no ".tmp" artifact remains in "$HOME/.claude/obsidian-memory/"
+
+  # --- AC7: "Already that state" is success ---
+
+  Scenario: Already-in-state is an informational success, not a rewrite
+    Given a config with "rag.enabled" set to true
+    And   a snapshot of the config file's mtime and inode
+    When  the user runs "vault-toggle.sh rag on"
+    Then  the exit code is 0
+    And   stdout contains "rag.enabled was already true"
+    And   the config file's mtime and inode match the snapshot
+
+  # --- AC8: State aliases (Scenario Outline) ---
+
+  Scenario Outline: State aliases resolve to the expected boolean
+    Given a config with "rag.enabled" set to <starting>
+    When  the user runs "vault-toggle.sh rag <alias>"
+    Then  the exit code is 0
+    And   the config has "rag.enabled" set to <expected>
+
+    Examples:
+      | starting | alias | expected |
+      | false    | on    | true     |
+      | false    | true  | true     |
+      | false    | 1     | true     |
+      | false    | yes   | true     |
+      | true     | off   | false    |
+      | true     | false | false    |
+      | true     | 0     | false    |
+      | true     | no    | false    |

--- a/specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/requirements.md
+++ b/specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/requirements.md
@@ -1,0 +1,264 @@
+# Requirements: Toggle Skill for rag/distill Enable Flags
+
+**Issues**: #4
+**Date**: 2026-04-21
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## User Story
+
+**As a** Claude Code + Obsidian user troubleshooting a hook or temporarily stepping out of RAG
+**I want** a one-command way to flip `rag.enabled` / `distill.enabled`
+**So that** I do not have to hand-edit `~/.claude/obsidian-memory/config.json` every time I need to disable a hook.
+
+---
+
+## Background
+
+`steering/product.md` names this explicitly as a v1 "Should Have": *"Disable-flag UX: clear docs + a skill that toggles `rag.enabled` / `distill.enabled` without editing JSON by hand."* Today, disabling either hook means opening the config in an editor, flipping the flag, saving — a friction point encountered exactly when the user is already debugging.
+
+Typical triggers for toggling:
+
+- The RAG hook is injecting context the user does not want for a specific working session.
+- Distillation is misbehaving and the user needs to stop writing to the vault while investigating.
+- The user wants to confirm that a problem originates from obsidian-memory by temporarily disabling it.
+
+The existing `/obsidian-memory:doctor` skill already routes users here: its remediation hints include `run /obsidian-memory:toggle rag on` and `run /obsidian-memory:toggle distill on` when a feature is reported disabled (see `skills/doctor/SKILL.md`). Shipping toggle closes that loop.
+
+**Path correction vs. the source issue.** The source issue's FR1 names the path `plugins/obsidian-memory/skills/toggle/SKILL.md`. Per `steering/structure.md` ("the repo root IS the plugin root"), the correct location is `skills/toggle/SKILL.md` — the repo is a standalone plugin, not a multi-plugin monorepo. Existing skills (`skills/setup/`, `skills/doctor/`, `skills/teardown/`, `skills/distill-session/`) confirm the layout. The FR below is written against the correct path.
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: Explicit enable flips the flag and reports the prior and new state
+
+**Given** a healthy config at `~/.claude/obsidian-memory/config.json` with `rag.enabled = true`
+**When** the user runs `/obsidian-memory:toggle rag off`
+**Then** `rag.enabled` becomes `false` in the config
+**And** the skill prints the previous value (`true`) and the new value (`false`) for `rag.enabled`
+**And** the skill exits 0.
+
+**Example**:
+- Given: config `{"vaultPath":"…","rag":{"enabled":true},"distill":{"enabled":true}}`
+- When: `vault-toggle.sh rag off`
+- Then: stdout contains `rag.enabled: true -> false`; config on disk now shows `"rag": {"enabled": false}`; exit code 0.
+
+### AC2: Toggle without an explicit state flips the current value
+
+**Given** a healthy config with `distill.enabled = false`
+**When** the user runs `/obsidian-memory:toggle distill` (no state argument)
+**Then** `distill.enabled` becomes `true` in the config
+**And** the skill reports the flip (`distill.enabled: false -> true`)
+**And** the skill exits 0.
+
+### AC3: Status read-out prints both flags and does not mutate the config
+
+**Given** any valid config
+**When** the user runs `/obsidian-memory:toggle status` — or `/obsidian-memory:toggle` with no arguments
+**Then** the skill prints the current value of both `rag.enabled` and `distill.enabled`
+**And** the config file's content, mtime, and inode are unchanged
+**And** the skill exits 0.
+
+**Example**:
+- Given: config with `rag.enabled=true`, `distill.enabled=false`
+- When: `vault-toggle.sh status`
+- Then: stdout contains `rag.enabled: true` and `distill.enabled: false`; config bytes on disk are byte-for-byte identical to the pre-run state.
+
+### AC4: Unknown feature name errors cleanly
+
+**Given** any valid config
+**When** the user runs `/obsidian-memory:toggle foobar on`
+**Then** the skill prints an error on stderr naming the allowed features (`rag`, `distill`)
+**And** the skill exits non-zero
+**And** the config file is unchanged (content, mtime, inode).
+
+### AC5: Missing config is a clean error, not a crash
+
+**Given** `~/.claude/obsidian-memory/config.json` does not exist
+**When** the user runs `/obsidian-memory:toggle rag on`
+**Then** the skill prints on stderr: `config not found — run /obsidian-memory:setup <vault> first`
+**And** the skill exits non-zero
+**And** no file is created under `~/.claude/obsidian-memory/`.
+
+### AC6: Writes are atomic — interrupted toggle never leaves a half-written config
+
+**Given** any valid toggle that will mutate the config
+**When** the skill rewrites the config
+**Then** it writes the new JSON to a temp file in the same directory as the config
+**And** it uses `mv` (atomic on the same filesystem) to replace the original
+**And** at no observable point is the config file truncated, empty, or containing a partial JSON document — even if the skill is killed mid-write (SIGKILL) the original config remains intact on disk.
+
+**Example**:
+- Given: config containing `"rag":{"enabled":true}` plus an unrelated user-added key `"customFoo":42`
+- When: `vault-toggle.sh rag off` runs to completion
+- Then: the post-run config still contains `"customFoo":42` byte-for-byte; the only change is the boolean; no `.tmp` artifacts remain in `~/.claude/obsidian-memory/`.
+
+### AC7: "Already that state" is a success, not an error
+
+**Given** `rag.enabled = true`
+**When** the user runs `/obsidian-memory:toggle rag on`
+**Then** the skill prints `rag.enabled was already true` (informational)
+**And** the skill exits 0
+**And** the config file's content, mtime, and inode are unchanged (no rewrite for a no-op).
+
+### AC8: On/off aliases are accepted
+
+**Given** a healthy config with `rag.enabled = true`
+**When** the user runs `/obsidian-memory:toggle rag <alias>` where `<alias>` is any of `off`, `false`, `0`, `no`
+**Then** `rag.enabled` becomes `false` (or is reported already-false per AC7 if it was already)
+**And** the same aliasing applies to `on`, `true`, `1`, `yes` → `true`.
+
+**Scenario Outline data**:
+
+| alias | expected value |
+|-------|----------------|
+| on    | true  |
+| true  | true  |
+| 1     | true  |
+| yes   | true  |
+| off   | false |
+| false | false |
+| 0     | false |
+| no    | false |
+
+### Generated Gherkin Preview
+
+```gherkin
+Feature: Toggle Skill for rag/distill Enable Flags
+  As a Claude Code + Obsidian user troubleshooting a hook or temporarily stepping out of RAG
+  I want a one-command way to flip rag.enabled / distill.enabled
+  So that I do not have to hand-edit ~/.claude/obsidian-memory/config.json every time
+
+  # one scenario per AC above (AC8 becomes a Scenario Outline)
+```
+
+---
+
+## Functional Requirements
+
+| ID  | Requirement | Priority | Notes |
+|-----|-------------|----------|-------|
+| FR1 | Ship the skill at `skills/toggle/SKILL.md` following the thin-relayer pattern used by `skills/doctor/SKILL.md` and `skills/teardown/SKILL.md`. | Must | Path is corrected from the issue's original `plugins/obsidian-memory/…`. See Background → *Path correction*. |
+| FR2 | Implement the logic in `scripts/vault-toggle.sh`; the skill shells out and relays stdout + exit code verbatim. | Must | Matches the doctor / teardown pattern — keeps behavior unit-testable with `bats` against a scratch `$HOME`. |
+| FR3 | Accept invocations: `toggle <feature> <state>`, `toggle <feature>` (flip), `toggle status`, `toggle` (status shorthand). | Must | `<state>` honors the aliases from FR8. |
+| FR4 | Feature whitelist is exactly `rag` and `distill`. Any other feature argument prints a usage line naming the allowed features to stderr and exits non-zero. | Must | Hard-coded list. No dynamic discovery. |
+| FR5 | Mutating writes are atomic: `jq` renders new JSON to a temp file in the same directory as the config, then `mv`-into-place. On success the temp file is gone; on any internal failure the original config is untouched. | Must | Required by AC6. |
+| FR6 | Preserve every unrelated key in the config (e.g., `vaultPath`, any user-added extensions). Use `jq --indent 2` so formatting matches what `/obsidian-memory:setup` writes. | Must | Regression guard: setup's tests will break if we drift from 2-space indent. |
+| FR7 | BDD scenarios cover: explicit on, explicit off, flip (no state arg), status, status-shorthand (no args), unknown feature, missing config, atomic-write survival, already-in-state no-op, and the state-alias Scenario Outline. | Must | Listed in tasks under the Testing phase. |
+| FR8 | Exit codes: 0 on success (including the already-in-state case), non-zero on any error (unknown feature, missing config, unreadable config, failed write). | Must | Aligns with exit-code semantics already used by doctor (0 vs 1) and teardown (0 / 1 / 2). |
+| FR9 | State aliases: accept `on`, `true`, `1`, `yes` as `true`; `off`, `false`, `0`, `no` as `false`. Case-insensitive. Anything else errors with a usage line. | Should | Upgraded from "Could" in the source issue — trivial to implement, non-trivial UX cost to omit. |
+| FR10 | Doctor skill cross-reference: no code change needed, but this spec inherits the existing `doctor` remediation hints (`run /obsidian-memory:toggle rag on` / `… distill on`). Verify on completion that those hints still resolve. | Must | Prevents circular doc rot. |
+
+---
+
+## Non-Functional Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Performance** | Toggle must complete in well under 100 ms on a warm filesystem. It is user-facing and interactive; no polling or sleeping. |
+| **Security** | No prompt text or untrusted input is ever interpolated into a shell command (per `steering/tech.md` → Security). All argv comes from the user's typed command line; no network calls. |
+| **Reliability** | Atomic write (FR5) guarantees the config is never left in a partial or corrupt state. A user killing the skill mid-run must not require `/obsidian-memory:setup` to recover. |
+| **Platforms** | macOS default bash 3.2 and Linux bash 4+ per `steering/tech.md`. BSD `mv` and `jq ≥ 1.6` are the only required tools (inherited from existing scripts). |
+
+---
+
+## UI/UX Requirements
+
+The skill has no UI other than stdout/stderr. Output conventions:
+
+| Element | Requirement |
+|---------|-------------|
+| **Mutation output** | `<feature>.enabled: <prev> -> <new>` on stdout, e.g., `rag.enabled: true -> false`. |
+| **No-op output** | `<feature>.enabled was already <value>` on stdout. |
+| **Status output** | Two lines, one per feature: `rag.enabled: true` and `distill.enabled: false`. |
+| **Error output** | Everything to stderr. First line starts with `ERROR:` so machine-parsers can filter. |
+| **Color** | None. Other scripts (`vault-doctor.sh`) use ANSI only behind `[ -t 1 ]`; this skill's output is simple enough to ship uncolored. |
+
+---
+
+## Data Requirements
+
+### Input Data
+
+| Field | Type | Validation | Required |
+|-------|------|------------|----------|
+| `<feature>` | string argv | exactly `rag` or `distill`; `status` is also accepted as a verb | No (absent = `status`) |
+| `<state>` | string argv | one of `on`, `off`, `true`, `false`, `1`, `0`, `yes`, `no` (case-insensitive) | No (absent = flip current value) |
+
+### Config file touched
+
+| Path | Keys read | Keys written |
+|------|-----------|--------------|
+| `~/.claude/obsidian-memory/config.json` | `.rag.enabled`, `.distill.enabled` (unset → treated as `true` per `_common.sh` semantics, but only for reporting; writes always produce an explicit boolean) | `.rag.enabled` or `.distill.enabled` (one at a time); every other key is preserved byte-for-byte |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+
+- [x] `/obsidian-memory:setup` must have already written `~/.claude/obsidian-memory/config.json`. Toggle does not create the config from scratch.
+- [x] `jq` ≥ 1.6 on `PATH` (required for read and atomic write).
+
+### External Dependencies
+
+None. Toggle is local-only — no network, no `claude -p` subprocess.
+
+### Blocked By
+
+None.
+
+---
+
+## Out of Scope
+
+- Per-project overrides (tracked by issue #6).
+- A global master-disable across all hooks at once ("kill switch"). If we want one, it gets its own issue.
+- Any UI beyond stdout/stderr text.
+- A config-migration / rename path — this skill only flips booleans, never renames keys.
+- Toggling keys other than `rag.enabled` and `distill.enabled`. Future features that want a toggle extend the FR4 whitelist in a separate issue.
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Time to disable a hook (user-observed) | ≤ 5 s from "I need to disable RAG" to flag flipped | Self-measured via session notes; no instrumentation. |
+| Config corruption events | 0 | Integration test asserts atomic-write invariant (AC6). |
+| Doctor remediation-hint accuracy | 100% of toggle invocations from doctor's hints succeed | Manual spot-check once shipped; covered implicitly by end-to-end BDD scenario. |
+
+---
+
+## Open Questions
+
+None. The source issue's "Notes" resolved the "already in state" semantics (AC7), and FR9 upgrades the aliasing question.
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #4 | 2026-04-21 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to PLAN phase:
+
+- [x] User story follows "As a / I want / So that" format
+- [x] All acceptance criteria use Given/When/Then format
+- [x] No implementation details in requirements (except FR-level file paths, which are deliberate)
+- [x] All criteria are testable and unambiguous
+- [x] Success metrics are measurable
+- [x] Edge cases (no-op, aliases, missing config, atomic write) are specified
+- [x] Dependencies are identified
+- [x] Out of scope is defined
+- [x] Open questions are documented (or resolved)

--- a/specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/tasks.md
+++ b/specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/tasks.md
@@ -1,0 +1,218 @@
+# Tasks: Toggle Skill for rag/distill Enable Flags
+
+**Issues**: #4
+**Date**: 2026-04-21
+**Status**: Planning
+**Author**: Rich Nunley
+
+---
+
+## Summary
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Setup | 1 | [ ] |
+| Backend | 2 | [ ] |
+| Integration | 1 | [ ] |
+| Testing | 3 | [ ] |
+| **Total** | 7 | |
+
+"Backend" is the shell implementation. "Integration" is the user-facing skill wrapper and doctor cross-reference verification.
+
+This feature has no Frontend phase — obsidian-memory is a CLI plugin with no UI components (per `steering/structure.md` → "Design Tokens / UI Standards: Not applicable").
+
+---
+
+## Task Format
+
+```
+### T[NNN]: [Task Title]
+
+**File(s)**: `path/to/file`
+**Type**: Create | Modify | Verify
+**Depends**: T[NNN] (or None)
+**Acceptance**:
+- [ ] [Verifiable criterion]
+```
+
+---
+
+## Phase 1: Setup
+
+### T001: Create feature directory structure
+
+**File(s)**: `skills/toggle/`, `tests/integration/`, `tests/features/steps/`
+**Type**: Create (directories only; actual files created in later tasks)
+**Depends**: None
+**Acceptance**:
+- [ ] `skills/toggle/` exists (empty, ready for SKILL.md in T004)
+- [ ] `tests/integration/` and `tests/features/steps/` already exist from prior work — verify presence, create if missing
+- [ ] `scripts/` already exists (contains `_common.sh`, `vault-rag.sh`, `vault-distill.sh`, `vault-doctor.sh`, `vault-teardown.sh`) — verify only
+
+**Notes**: Idempotent directory prep. No new test dirs are needed — existing harness directories are reused.
+
+---
+
+## Phase 2: Backend Implementation
+
+### T002: Implement `vault-toggle.sh`
+
+**File(s)**: `scripts/vault-toggle.sh`
+**Type**: Create
+**Depends**: T001
+**Acceptance**:
+- [ ] Shebang `#!/usr/bin/env bash`; `set -u`; `trap` at top level per `steering/tech.md` Bash standards
+- [ ] Top-level `trap 'rm -f "$TMP" 2>/dev/null || true' EXIT` — cleans any temp-file droppings on exit
+- [ ] Does **NOT** source `_common.sh::om_load_config` — rationale captured in `design.md` → Alternatives Considered → Option B
+- [ ] Reads `$HOME/.claude/obsidian-memory/config.json` directly
+- [ ] Arg parsing implements the full CLI grammar from `design.md` → API:
+  - 0 args → mode=status
+  - 1 arg == `status` → mode=status
+  - 1 arg (any `<feature>`) → mode=flip
+  - 2 args (`<feature>`, `<state>`) → mode=set
+  - 3+ args → usage on stderr + exit 2
+- [ ] Feature whitelist enforced: any feature not in `{rag, distill}` → `ERROR: unknown feature '<arg>' — allowed: rag, distill` on stderr + exit 2
+- [ ] State alias table enforced (case-insensitive):
+  - `on`, `true`, `1`, `yes` → `true`
+  - `off`, `false`, `0`, `no` → `false`
+  - Anything else → `ERROR: unknown state …` on stderr + exit 2
+- [ ] Missing config → `ERROR: config not found — run /obsidian-memory:setup <vault> first` on stderr + exit 1
+- [ ] Missing `jq` → `ERROR: jq missing — install jq (brew install jq)` on stderr + exit 1
+- [ ] Status mode reads `.rag.enabled` and `.distill.enabled` via jq; prints two lines `rag.enabled: <bool>` and `distill.enabled: <bool>`; exit 0
+- [ ] Unset feature stanza normalizes to `true` for reporting (matches `_common.sh` semantics — see `design.md` → Risks → "missing feature stanza")
+- [ ] Mutation uses atomic write: `jq --indent 2 --argjson v <bool> '.<feature>.enabled = $v' "$CONFIG" > "$TMP" && mv "$TMP" "$CONFIG"`
+- [ ] `$TMP` lives in the same directory as `$CONFIG` (`"$CONFIG.tmp.$$"`), never under `/tmp`
+- [ ] On mutation success, prints `<feature>.enabled: <prev> -> <new>` on stdout + exit 0
+- [ ] On flip (no explicit state), computes the inverse of the current value before the write
+- [ ] On "already in state" (explicit set equals current), prints `<feature>.enabled was already <value>` on stdout + exit 0 **without rewriting** the config file (mtime and inode unchanged)
+- [ ] Error first line on stderr always starts with literal `ERROR:` (per FR-level convention in `design.md`)
+- [ ] Passes `shellcheck scripts/vault-toggle.sh`
+- [ ] Script is chmod +x
+
+**Notes**: Reference `scripts/vault-doctor.sh` for the "user-invoked, errors must surface" style and `scripts/vault-teardown.sh` for the atomic-write / trap-based cleanup idiom. The `--argjson` form is required so `jq` parses the boolean as a JSON literal rather than a string.
+
+### T003: Verify key-preservation behavior
+
+**File(s)**: `scripts/vault-toggle.sh` (same script as T002)
+**Type**: Verify (no new file)
+**Depends**: T002
+**Acceptance**:
+- [ ] A config containing unrelated user-added keys (e.g., `"customFoo": 42`) round-trips every key byte-for-byte after a toggle
+- [ ] A config written by `/obsidian-memory:setup` (2-space indent, specific key order) retains its formatting after a toggle — no diff other than the flipped boolean
+- [ ] A config where the feature stanza is absent (e.g., no `"distill"` key at all) gets the stanza auto-created by `jq` when the user runs `toggle distill on`; other keys are still preserved
+
+**Notes**: This is a gate, not a new implementation task — it verifies the `jq --indent 2` + whole-document round-trip chosen in `design.md` → Key-preservation rules. Tests from Phase 3 exercise all three cases; T003 closes when those tests are green.
+
+---
+
+## Phase 3: Integration
+
+### T004: Write the `toggle` SKILL.md
+
+**File(s)**: `skills/toggle/SKILL.md`
+**Type**: Create
+**Depends**: T002
+**Acceptance**:
+- [ ] Frontmatter matches the shape in `design.md` → New: `skills/toggle/SKILL.md`:
+  - `name: toggle`
+  - `description:` includes trigger phrases ("disable rag", "enable distill", "turn off obsidian memory hook", "toggle rag", "/obsidian-memory:toggle")
+  - `argument-hint: [<feature> [<state>]]`
+  - `allowed-tools: Bash, Read`
+  - `model: sonnet`
+  - `effort: low`
+- [ ] Body sections present: one-paragraph summary, **When to Use**, **When NOT to Use**, **Invocation**, **Behavior** (relay only), **Exit Code Contract**, **Error Handling**, **Idempotency**, **Related skills** — mirrors the section list in `skills/doctor/SKILL.md`
+- [ ] Behavior section explicitly instructs Claude to invoke `"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/obsidian-memory}/scripts/vault-toggle.sh" "$@"` and to **relay the script's stdout and exit code verbatim** — do not re-interpret, do not re-run
+- [ ] Exit Code Contract table lists `0`, `1`, `2` with the semantics from `design.md`
+- [ ] Related skills section cross-references `/obsidian-memory:setup` (prerequisite for the config), `/obsidian-memory:doctor` (diagnoses + links back to toggle), and `/obsidian-memory:distill-session` (alternative to "disable distill" if the user only wants to skip one session)
+
+**Notes**: No logic in the SKILL body. Every code path is in the script. Matches `skills/doctor/SKILL.md` and `skills/teardown/SKILL.md` precisely.
+
+---
+
+## Phase 4: BDD Testing (Required)
+
+### T005: Write the Gherkin feature file
+
+**File(s)**: `specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/feature.gherkin`
+**Type**: Create (supplied alongside this tasks.md)
+**Depends**: T002
+**Acceptance**:
+- [ ] One scenario per AC1–AC7 from `requirements.md`
+- [ ] AC8 is a `Scenario Outline` with the alias table as Examples
+- [ ] Uses Given/When/Then format per `tech.md` → BDD Testing
+- [ ] Valid Gherkin syntax (parses with the `tests/run-bdd.sh` runner)
+
+**Notes**: The file is created alongside this tasks.md so it is reviewable at spec time. T006 implements the step definitions it calls.
+
+### T006: Implement step definitions for the Gherkin scenarios
+
+**File(s)**: `tests/features/steps/toggle.sh`
+**Type**: Create
+**Depends**: T002, T005
+**Acceptance**:
+- [ ] One step-definition function per unique Given/When/Then phrase in the feature file
+- [ ] Given-step helpers write scratch config to `$HOME/.claude/obsidian-memory/config.json` under the scratch harness (`tests/helpers/scratch.bash` already redirects `$HOME`)
+- [ ] When-step helpers invoke `"$PLUGIN_ROOT/scripts/vault-toggle.sh"` with the tested argv and capture stdout, stderr, exit code into per-scenario vars
+- [ ] Then-step helpers assert against the captured output and re-read the config back to assert persisted state
+- [ ] Follows the naming / structure conventions in `tests/features/steps/doctor.sh` and `tests/features/steps/teardown.sh`
+- [ ] Runs under `tests/run-bdd.sh`; exits 0
+
+### T007: Write bats integration tests for `vault-toggle.sh`
+
+**File(s)**: `tests/integration/toggle.bats`
+**Type**: Create
+**Depends**: T002
+**Acceptance**:
+- [ ] `setup()` loads `../helpers/scratch` and sets `TOGGLE="$PLUGIN_ROOT/scripts/vault-toggle.sh"`
+- [ ] Each case below is a distinct `@test`:
+  1. status prints both flags (happy path)
+  2. status-shorthand (no args) equivalent to explicit `status`
+  3. `rag off` flips true → false, persists to disk, exit 0
+  4. `rag on` on already-true reports "was already" + exit 0 + mtime/inode unchanged (assert via `stat`)
+  5. `distill` (no state) flips the current value
+  6. `foobar on` prints `ERROR: unknown feature` to stderr + exit 2 + config unchanged
+  7. `rag maybe` prints `ERROR: unknown state` to stderr + exit 2 + config unchanged
+  8. Missing config → `ERROR: config not found` to stderr + exit 1 + no file created
+  9. Unrelated user keys (`customFoo: 42`) survive a toggle byte-for-byte (assert with `diff`/`jq`)
+  10. Missing feature stanza (no `distill` key at all) — `toggle distill on` creates the stanza; other keys preserved
+  11. Atomic-write invariant: forcibly delete the `.tmp.$$` file *before* mv via a wedge (e.g., stub the `mv` call to fail) and confirm original config is untouched (covers the "mv failed" branch — requires driving the script with `PATH` pointing at a `mv` stub in `$BATS_TEST_TMPDIR/bin/`)
+  12. Shellcheck gate (`shellcheck scripts/vault-toggle.sh` returns 0)
+- [ ] `teardown()` calls `assert_home_untouched` — proves the real `~/.claude/obsidian-memory/` was never mutated during the run
+
+**Notes**: The test for case 11 is the strongest guarantee of the AC6 atomic-write invariant. Use the same PATH-stub pattern that `tests/integration/teardown.bats` uses for its `claude mcp remove` stub.
+
+---
+
+## Dependency Graph
+
+```
+T001 ──▶ T002 ──┬──▶ T003 (verify key preservation)
+                ├──▶ T004 (SKILL.md)
+                ├──▶ T005 (gherkin)──▶ T006 (steps)
+                └──▶ T007 (bats)
+```
+
+Critical path: **T001 → T002 → T007** (the atomic-write test is the last thing to go green and the highest-risk assertion).
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #4 | 2026-04-21 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to IMPLEMENT phase:
+
+- [x] Each task has single responsibility
+- [x] Dependencies are correctly mapped
+- [x] Tasks can be completed independently (given dependencies)
+- [x] Acceptance criteria are verifiable
+- [x] File paths reference actual project structure (per `steering/structure.md`)
+- [x] Test tasks are included for each layer (shellcheck + bats + BDD)
+- [x] No circular dependencies
+- [x] Tasks are in logical execution order

--- a/specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/verification/report.md
+++ b/specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/verification/report.md
@@ -1,0 +1,128 @@
+# Verification Report: Issue #4 — `/obsidian-memory:toggle` skill
+
+**Date**: 2026-04-21
+**Branch**: `4-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags`
+**Verifier**: `/verify-code` (unattended mode)
+
+---
+
+## Executive Summary
+
+**Implementation Status**: **Pass**
+
+The toggle skill and its backing `scripts/vault-toggle.sh` satisfy every acceptance criterion in `requirements.md`, every task in `tasks.md`, and every architectural expectation in `steering/tech.md` + `steering/structure.md`. All five steering verification gates are green, the 20 bats scenarios in `tests/integration/toggle.bats` pass, and the nine Gherkin scenarios in `feature.gherkin` pass under `tests/run-bdd.sh`. Architecture review scored 5/5 across SOLID, Security, Performance, Testability, and Error Handling — no critical, high, or medium findings.
+
+No fixes required.
+
+---
+
+## Acceptance Criteria
+
+| AC  | Criterion | Status | Evidence |
+|-----|-----------|--------|----------|
+| AC1 | Explicit enable flips the flag and reports prev → new | ✅ Pass | `toggle.bats` #3 `rag_off`, #4 `distill_on`; BDD "Explicit 'off' flips rag.enabled …" |
+| AC2 | Toggle without state flips current value | ✅ Pass | `toggle.bats` #6 `flip_true_to_false`, #7 `flip_false_to_true`; BDD "Toggle without an explicit state …" |
+| AC3 | Status prints both flags, does not mutate | ✅ Pass | `toggle.bats` #1, #2 (mtime/inode preserved); BDD "Status prints both flags …" + "No-arg invocation is equivalent to status" |
+| AC4 | Unknown feature errors cleanly (exit 2, config unchanged) | ✅ Pass | `toggle.bats` #11 `unknown_feature`; BDD "Unknown feature name exits non-zero …" |
+| AC5 | Missing config is a clean error | ✅ Pass | `toggle.bats` #14 `missing_config`; BDD "Missing config file reports a setup hint …" |
+| AC6 | Atomic write — original config survives interrupted toggle | ✅ Pass | `toggle.bats` #19 `atomic_write_mv_fails` (cksum byte-equality after failed mv); BDD "Atomic write — original config survives a failed mv" |
+| AC7 | "Already that state" is a success, no rewrite | ✅ Pass | `toggle.bats` #5 `already_in_state` (mtime/inode preserved); BDD "Already-in-state is an informational success …" |
+| AC8 | On/off aliases accepted (`on`/`off`/`true`/`false`/`1`/`0`/`yes`/`no`, case-insensitive) | ✅ Pass | `toggle.bats` #8 `alias_on_variants`, #9 `alias_off_variants`, #10 `alias_case_insensitive` (feature.gherkin Scenario Outline skipped by runner, covered by bats) |
+
+**Task completion (from `tasks.md`)**:
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T001 | ✅ | Directories exist |
+| T002 | ✅ | `scripts/vault-toggle.sh` implemented, shellcheck-clean |
+| T003 | ✅ | Key-preservation tests green (`preserve_unrelated_keys`, `preserve_2space_indent`, `missing_feature_stanza`) |
+| T004 | ✅ | `skills/toggle/SKILL.md` written with frontmatter matching shipped-skill convention |
+| T005 | ✅ | `feature.gherkin` present with 8 scenarios + 1 Scenario Outline |
+| T006 | ✅ | `tests/features/steps/toggle.sh` present; 9 scenarios resolve and pass |
+| T007 | ✅ | `tests/integration/toggle.bats` present; 20 scenarios pass |
+
+---
+
+## Architecture Review
+
+| Area | Score (1–5) |
+|------|-------------|
+| SOLID Principles | 5 |
+| Security | 5 |
+| Performance | 5 |
+| Testability | 5 |
+| Error Handling | 5 |
+
+**Highlights (from architecture-reviewer subagent)**:
+
+- **SOLID** — clean separation: `normalize_state`, `read_flag`, `write_flag`, `ensure_preconditions`, `cmd_status`, `cmd_set`, `cmd_flip`. Skill is purely declarative per `structure.md`'s layer rule.
+- **Security** — feature name is whitelisted *before* reaching jq (`vault-toggle.sh:152-159`), state values reach jq only via `--argjson` with the already-normalized literal `true`/`false`. No injection surface. Atomic write stays on the same filesystem; EXIT trap cleans temp droppings.
+- **Performance** — two jq invocations worst case; `cmd_status` collapses to one via `@tsv`. Appropriate for a user-invoked CLI.
+- **Testability** — 20 bats + 9 BDD scenarios; scratch `$HOME` + `assert_home_untouched` teardown guarantees the operator's real config is untouched. `atomic_write_mv_fails` uses a PATH-shadow `mv` stub to prove AC6.
+- **Error Handling** — every error path emits `ERROR:` first-line-of-stderr; exit codes (0 / 1 / 2) are documented and distinct. Unset-flag ambiguity is handled explicitly via `jq`'s `null` check at `vault-toggle.sh:66`.
+
+**Low-severity observations** (informational, no fix required):
+
+- Some bats assertions use `[[ "$stderr" == ... ]] || [[ "$output" == ... ]]` as a cross-version fallback. Defensive, not a defect (`toggle.bats:178, 188, 203`).
+- The ERR trap is effectively a safety net; explicit `log_err + exit` paths supersede it. Correct behaviour.
+
+---
+
+## Test Coverage
+
+| Layer | Result |
+|-------|--------|
+| `tests/integration/toggle.bats` | **20 / 20 pass** |
+| `tests/run-bdd.sh specs/feature-…-toggle-…/feature.gherkin` | **9 / 9 scenarios pass** (Scenario Outline skipped by runner; alias coverage provided by bats) |
+| `tests/integration` full suite (all features) | **62 / 62 pass** |
+| `shellcheck scripts/vault-toggle.sh tests/integration/toggle.bats tests/features/steps/toggle.sh` | **Pass** (exit 0) |
+
+Every AC has at least one Gherkin scenario and at least one bats test. The 8-alias case-insensitive matrix (AC8) is exercised via bats `alias_on_variants`, `alias_off_variants`, and `alias_case_insensitive` — the Gherkin Scenario Outline is deliberately left unresolved by `run-bdd.sh`'s documented subset (see `tests/run-bdd.sh:247`).
+
+---
+
+## Exercise Test Results
+
+**Skipped — graceful degradation.**
+
+- Plugin change detected (`skills/toggle/SKILL.md` matches the standalone-plugin pattern).
+- `@anthropic-ai/claude-agent-sdk` not resolvable (`require.resolve` exit 1). `claude` CLI is available.
+- The skill is a **pure thin relayer**: every code path lives in `scripts/vault-toggle.sh` and is covered by 20 bats + 9 BDD scenarios. Exercising via nested `claude -p` from inside an active Claude Code session risks environment contamination without adding AC-level coverage beyond what bats/BDD already provide. Per `exercise-testing.md` the run is skipped and recorded here; no finding is generated.
+
+---
+
+## Steering Doc Verification Gates
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Shellcheck | ✅ Pass | `shellcheck scripts/vault-toggle.sh tests/integration/toggle.bats tests/features/steps/toggle.sh tests/helpers/scratch.bash tests/run-bdd.sh` → exit 0 |
+| Unit Tests | ✅ Pass | `bats tests/unit` → 1/1 pass |
+| Integration Tests | ✅ Pass | `bats tests/integration` → 62/62 pass |
+| BDD Tests | ✅ Pass | `tests/run-bdd.sh specs/feature-…-toggle-…/feature.gherkin` → 9/9 pass, 0 failed, 0 undefined |
+| JSON validity | ✅ Pass | `jq empty .claude-plugin/plugin.json hooks/hooks.json` → exit 0 |
+
+**Gate Summary**: 5 / 5 passed, 0 failed, 0 incomplete.
+
+Note: the full BDD suite across *every* spec (`tests/run-bdd.sh` with no argument) exercises the session-distillation feature which shells out to `claude -p` and takes minutes; the toggle-scoped run was the relevant evidence for this verification and it passes cleanly.
+
+---
+
+## Fixes Applied
+
+None. No critical/high/medium findings were identified by either the architecture review or the steering-doc gates.
+
+---
+
+## Remaining Issues
+
+| Severity | Category | Location | Issue | Reason Not Fixed |
+|----------|----------|----------|-------|------------------|
+| — | — | — | — | — |
+
+No remaining issues.
+
+---
+
+## Recommendation
+
+**Ready for PR.** Every acceptance criterion is implemented, every task is complete, every steering gate is green, and architecture review returned 5/5 across all areas with no actionable findings. Proceed to `/open-pr #4`.

--- a/tests/features/steps/toggle.sh
+++ b/tests/features/steps/toggle.sh
@@ -1,0 +1,291 @@
+# tests/features/steps/toggle.sh — step definitions for
+# specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/feature.gherkin (#4).
+#
+# Exercises scripts/vault-toggle.sh end-to-end against the scratch harness.
+# Every filesystem mutation lives under $BATS_TEST_TMPDIR — the operator's
+# real ~/.claude is never touched.
+
+# shellcheck shell=bash
+# shellcheck disable=SC2154,SC2153
+# SC2154/SC2153 fire for VAULT/HOME/PLUGIN_ROOT/BATS_TEST_TMPDIR — all
+# exported by tests/helpers/scratch.bash before this file is sourced.
+
+# Per-scenario state.
+TG_STDOUT=""
+TG_STDERR=""
+TG_RC=0
+TG_SNAPSHOT=""
+
+_toggle_config_path() {
+  printf '%s' "$HOME/.claude/obsidian-memory/config.json"
+}
+
+_toggle_script() {
+  printf '%s' "$PLUGIN_ROOT/scripts/vault-toggle.sh"
+}
+
+# Write a baseline healthy config with both flags set to the given values.
+_toggle_write_baseline() {
+  local rag="${1:-true}" distill="${2:-true}"
+  mkdir -p "$(dirname "$(_toggle_config_path)")"
+  cat > "$(_toggle_config_path)" <<EOF
+{
+  "vaultPath": "$VAULT",
+  "rag": {
+    "enabled": $rag
+  },
+  "distill": {
+    "enabled": $distill
+  }
+}
+EOF
+}
+
+# Ensure a specific flag key has a specific JSON value, preserving siblings.
+_toggle_set_flag() {
+  local key="$1" value="$2" cfg tmp
+  cfg="$(_toggle_config_path)"
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/toggle-cfg.XXXXXX")"
+  jq --arg k "$key" --argjson v "$value" 'setpath($k | split("."); $v)' "$cfg" > "$tmp"
+  mv "$tmp" "$cfg"
+}
+
+# BSD / GNU stat abstraction — returns "<inode>-<mtime>".
+_toggle_stat_fingerprint() {
+  if stat -f '%i-%m' "$1" 2>/dev/null; then return 0; fi
+  stat -c '%i-%Y' "$1"
+}
+
+# Parse a "vault-toggle.sh <args>" command line into an argv array passed to
+# the script. No quoting semantics are needed — the gherkin authors only pass
+# simple tokens (rag, off, status, foobar).
+_toggle_run_from_cmdline() {
+  local cmd="$1"
+  local rest="${cmd#vault-toggle.sh}"
+  # Trim leading whitespace.
+  rest="${rest# }"
+  TG_STDERR="$(mktemp "$BATS_TEST_TMPDIR/toggle.err.XXXXXX")"
+  local script
+  script="$(_toggle_script)"
+  if [ -z "$rest" ]; then
+    TG_STDOUT="$("$script" 2>"$TG_STDERR")"
+  else
+    # shellcheck disable=SC2086
+    TG_STDOUT="$("$script" $rest 2>"$TG_STDERR")"
+  fi
+  TG_RC=$?
+}
+
+# Install a PATH-shadowed stub for $1 whose body is whatever is piped in via
+# the heredoc in the caller. Used by the "a 'mv' stub that always exits
+# non-zero" step.
+_toggle_install_stub() {
+  local binary="$1"
+  local bindir="$BATS_TEST_TMPDIR/togglebin"
+  if [ ! -f "$bindir/.initialized" ]; then
+    mkdir -p "$bindir"
+    local d f name
+    local IFS_SAVED="$IFS"
+    IFS=':'
+    for d in $PATH; do
+      [ -d "$d" ] || continue
+      for f in "$d"/*; do
+        [ -x "$f" ] || continue
+        name="$(basename "$f")"
+        [ -e "$bindir/$name" ] && continue
+        ln -s "$f" "$bindir/$name" 2>/dev/null || true
+      done
+    done
+    IFS="$IFS_SAVED"
+    : > "$bindir/.initialized"
+  fi
+
+  rm -f "$bindir/$binary"
+  cat > "$bindir/$binary" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "$bindir/$binary"
+  PATH="$bindir"
+  export PATH
+}
+
+# ------------------------------------------------------------
+# Given steps
+# ------------------------------------------------------------
+
+# Given obsidian-memory is installed at "$PLUGIN_ROOT"
+given_obsidian_memory_is_installed_at() {
+  local path="${1:-}"
+  [ -n "$path" ] || return 1
+  [ -d "$path" ] || return 1
+  [ -x "$path/scripts/vault-toggle.sh" ]
+}
+
+# Given a config at "<path>" with "<key>" set to true
+given_a_config_at_with_set_to_true() {
+  local path="${1:-}" key="${2:-}"
+  [ -n "$path" ] && [ -n "$key" ] || return 1
+  _toggle_write_baseline true true
+  _toggle_set_flag "$key" true
+}
+
+# Given a config at "<path>" with "<key>" set to false
+given_a_config_at_with_set_to_false() {
+  local path="${1:-}" key="${2:-}"
+  [ -n "$path" ] && [ -n "$key" ] || return 1
+  _toggle_write_baseline true true
+  _toggle_set_flag "$key" false
+}
+
+# Given a config with "<key>" set to true
+given_a_config_with_set_to_true() {
+  local key="${1:-}"
+  [ -n "$key" ] || return 1
+  _toggle_write_baseline true true
+  _toggle_set_flag "$key" true
+}
+
+# Given a config with "rag.enabled" true and "distill.enabled" false
+given_a_config_with_true_and_false() {
+  local key1="${1:-}" key2="${2:-}"
+  [ -n "$key1" ] && [ -n "$key2" ] || return 1
+  _toggle_write_baseline true true
+  _toggle_set_flag "$key1" true
+  _toggle_set_flag "$key2" false
+}
+
+# Given a config with "rag.enabled" true and "distill.enabled" true
+given_a_config_with_true_and_true() {
+  local key1="${1:-}" key2="${2:-}"
+  [ -n "$key1" ] && [ -n "$key2" ] || return 1
+  _toggle_write_baseline true true
+  _toggle_set_flag "$key1" true
+  _toggle_set_flag "$key2" true
+}
+
+# And a snapshot of the config file's mtime and inode
+given_a_snapshot_of_the_config_file_s_mtime_and_inode() {
+  TG_SNAPSHOT="$(_toggle_stat_fingerprint "$(_toggle_config_path)")"
+}
+
+# Given there is no config file at "<path>"
+given_there_is_no_config_file_at() {
+  local path="${1:-}"
+  [ -n "$path" ] || return 1
+  rm -f "$path"
+  [ ! -e "$path" ]
+}
+
+# And the config contains an unrelated user key "customFoo" set to 42
+given_the_config_contains_an_unrelated_user_key_set_to_42() {
+  local key="${1:-}"
+  [ -n "$key" ] || return 1
+  _toggle_set_flag "$key" 42
+}
+
+# And a "mv" stub on PATH that always exits non-zero
+given_a_stub_on_path_that_always_exits_non_zero() {
+  local binary="${1:-}"
+  [ -n "$binary" ] || return 1
+  _toggle_install_stub "$binary"
+}
+
+# ------------------------------------------------------------
+# When steps
+# ------------------------------------------------------------
+
+# When the user runs "<command line>"
+when_the_user_runs() {
+  local cmd="${1:-}"
+  _toggle_run_from_cmdline "$cmd"
+}
+
+# ------------------------------------------------------------
+# Then steps
+# ------------------------------------------------------------
+
+then_the_exit_code_is_0() {
+  [ "$TG_RC" -eq 0 ]
+}
+
+then_the_exit_code_is_1() {
+  [ "$TG_RC" -eq 1 ]
+}
+
+then_the_exit_code_is_2() {
+  [ "$TG_RC" -eq 2 ]
+}
+
+# And stdout contains "<needle>"
+then_stdout_contains() {
+  local needle="${1:-}"
+  printf '%s' "$TG_STDOUT" | grep -qF -- "$needle"
+}
+
+# And stderr contains "<needle>"
+then_stderr_contains() {
+  local needle="${1:-}"
+  grep -qF -- "$needle" "$TG_STDERR"
+}
+
+# And the config at "<path>" has "<key>" set to false
+then_the_config_at_has_set_to_false() {
+  local path="${1:-}" key="${2:-}"
+  [ -n "$path" ] && [ -n "$key" ] || return 1
+  [ "$(jq -r --arg k "$key" 'getpath($k | split("."))' "$path")" = "false" ]
+}
+
+# And the config has "<key>" set to true
+then_the_config_has_set_to_true() {
+  local key="${1:-}"
+  [ -n "$key" ] || return 1
+  [ "$(jq -r --arg k "$key" 'getpath($k | split("."))' "$(_toggle_config_path)")" = "true" ]
+}
+
+# And the config file's mtime and inode match the snapshot
+then_the_config_file_s_mtime_and_inode_match_the_snapshot() {
+  local current
+  current="$(_toggle_stat_fingerprint "$(_toggle_config_path)")"
+  [ "$current" = "$TG_SNAPSHOT" ]
+}
+
+# And no file exists at "<path>"
+then_no_file_exists_at() {
+  local path="${1:-}"
+  [ -n "$path" ] || return 1
+  [ ! -e "$path" ]
+}
+
+# And the config at "<path>" still has "<key>" set to true
+then_the_config_at_still_has_set_to_true() {
+  local path="${1:-}" key="${2:-}"
+  [ -n "$path" ] && [ -n "$key" ] || return 1
+  [ "$(jq -r --arg k "$key" 'getpath($k | split("."))' "$path")" = "true" ]
+}
+
+# And the config still has "<key>" set to 42
+then_the_config_still_has_set_to_42() {
+  local key="${1:-}"
+  [ -n "$key" ] || return 1
+  [ "$(jq -r --arg k "$key" 'getpath($k | split("."))' "$(_toggle_config_path)")" = "42" ]
+}
+
+# And no ".tmp" artifact remains in "<dir>"
+then_no_artifact_remains_in() {
+  local pattern="${1:-.tmp}" dir="${2:-}"
+  [ -n "$dir" ] || return 1
+  # Any file in $dir whose name contains $pattern fails the assertion.
+  local hits
+  hits="$(find "$dir" -mindepth 1 -maxdepth 1 -name "*${pattern}*" 2>/dev/null | head -n 1)"
+  [ -z "$hits" ]
+}
+
+# And the config uses 2-space indentation
+then_the_config_uses_2_space_indentation() {
+  local cfg
+  cfg="$(_toggle_config_path)"
+  # Two-space body lines ("  \"<key>\": ...") and four-space nested lines
+  # ("    \"enabled\": ...") are both produced by `jq --indent 2`.
+  grep -q '^  "' "$cfg" && grep -q '^    "enabled"' "$cfg"
+}

--- a/tests/features/steps/toggle.sh
+++ b/tests/features/steps/toggle.sh
@@ -36,12 +36,6 @@ _toggle_write_baseline() {
 EOF
 }
 
-# BSD / GNU stat abstraction — returns "<inode>-<mtime>".
-_toggle_stat_fingerprint() {
-  if stat -f '%i-%m' "$1" 2>/dev/null; then return 0; fi
-  stat -c '%i-%Y' "$1"
-}
-
 # Parse a "vault-toggle.sh <args>" command line into an argv array passed to
 # the script. No quoting semantics are needed — the gherkin authors only pass
 # simple tokens (rag, off, status, foobar).
@@ -62,38 +56,16 @@ _toggle_run_from_cmdline() {
   TG_RC=$?
 }
 
-# Install a PATH-shadowed stub for $1 whose body is whatever is piped in via
-# the heredoc in the caller. Used by the "a 'mv' stub that always exits
-# non-zero" step.
 _toggle_install_stub() {
   local binary="$1"
-  local bindir="$BATS_TEST_TMPDIR/togglebin"
-  if [ ! -f "$bindir/.initialized" ]; then
-    mkdir -p "$bindir"
-    local d f name
-    local IFS_SAVED="$IFS"
-    IFS=':'
-    for d in $PATH; do
-      [ -d "$d" ] || continue
-      for f in "$d"/*; do
-        [ -x "$f" ] || continue
-        name="$(basename "$f")"
-        [ -e "$bindir/$name" ] && continue
-        ln -s "$f" "$bindir/$name" 2>/dev/null || true
-      done
-    done
-    IFS="$IFS_SAVED"
-    : > "$bindir/.initialized"
-  fi
-
+  _init_safe_path
+  local bindir="$BATS_TEST_TMPDIR/safebin"
   rm -f "$bindir/$binary"
   cat > "$bindir/$binary" <<'STUB'
 #!/usr/bin/env bash
 exit 1
 STUB
   chmod +x "$bindir/$binary"
-  PATH="$bindir"
-  export PATH
 }
 
 # ------------------------------------------------------------
@@ -152,7 +124,7 @@ given_a_config_with_true_and_true() {
 
 # And a snapshot of the config file's mtime and inode
 given_a_snapshot_of_the_config_file_s_mtime_and_inode() {
-  TG_SNAPSHOT="$(_toggle_stat_fingerprint "$(_config_path)")"
+  TG_SNAPSHOT="$(_stat_fingerprint "$(_config_path)")"
 }
 
 # Given there is no config file at "<path>"
@@ -232,7 +204,7 @@ then_the_config_has_set_to_true() {
 # And the config file's mtime and inode match the snapshot
 then_the_config_file_s_mtime_and_inode_match_the_snapshot() {
   local current
-  current="$(_toggle_stat_fingerprint "$(_config_path)")"
+  current="$(_stat_fingerprint "$(_config_path)")"
   [ "$current" = "$TG_SNAPSHOT" ]
 }
 

--- a/tests/features/steps/toggle.sh
+++ b/tests/features/steps/toggle.sh
@@ -10,15 +10,10 @@
 # SC2154/SC2153 fire for VAULT/HOME/PLUGIN_ROOT/BATS_TEST_TMPDIR — all
 # exported by tests/helpers/scratch.bash before this file is sourced.
 
-# Per-scenario state.
 TG_STDOUT=""
 TG_STDERR=""
 TG_RC=0
 TG_SNAPSHOT=""
-
-_toggle_config_path() {
-  printf '%s' "$HOME/.claude/obsidian-memory/config.json"
-}
 
 _toggle_script() {
   printf '%s' "$PLUGIN_ROOT/scripts/vault-toggle.sh"
@@ -27,8 +22,8 @@ _toggle_script() {
 # Write a baseline healthy config with both flags set to the given values.
 _toggle_write_baseline() {
   local rag="${1:-true}" distill="${2:-true}"
-  mkdir -p "$(dirname "$(_toggle_config_path)")"
-  cat > "$(_toggle_config_path)" <<EOF
+  mkdir -p "$(dirname "$(_config_path)")"
+  cat > "$(_config_path)" <<EOF
 {
   "vaultPath": "$VAULT",
   "rag": {
@@ -39,15 +34,6 @@ _toggle_write_baseline() {
   }
 }
 EOF
-}
-
-# Ensure a specific flag key has a specific JSON value, preserving siblings.
-_toggle_set_flag() {
-  local key="$1" value="$2" cfg tmp
-  cfg="$(_toggle_config_path)"
-  tmp="$(mktemp "$BATS_TEST_TMPDIR/toggle-cfg.XXXXXX")"
-  jq --arg k "$key" --argjson v "$value" 'setpath($k | split("."); $v)' "$cfg" > "$tmp"
-  mv "$tmp" "$cfg"
 }
 
 # BSD / GNU stat abstraction — returns "<inode>-<mtime>".
@@ -127,7 +113,7 @@ given_a_config_at_with_set_to_true() {
   local path="${1:-}" key="${2:-}"
   [ -n "$path" ] && [ -n "$key" ] || return 1
   _toggle_write_baseline true true
-  _toggle_set_flag "$key" true
+  _config_set_field "$key" true
 }
 
 # Given a config at "<path>" with "<key>" set to false
@@ -135,7 +121,7 @@ given_a_config_at_with_set_to_false() {
   local path="${1:-}" key="${2:-}"
   [ -n "$path" ] && [ -n "$key" ] || return 1
   _toggle_write_baseline true true
-  _toggle_set_flag "$key" false
+  _config_set_field "$key" false
 }
 
 # Given a config with "<key>" set to true
@@ -143,7 +129,7 @@ given_a_config_with_set_to_true() {
   local key="${1:-}"
   [ -n "$key" ] || return 1
   _toggle_write_baseline true true
-  _toggle_set_flag "$key" true
+  _config_set_field "$key" true
 }
 
 # Given a config with "rag.enabled" true and "distill.enabled" false
@@ -151,8 +137,8 @@ given_a_config_with_true_and_false() {
   local key1="${1:-}" key2="${2:-}"
   [ -n "$key1" ] && [ -n "$key2" ] || return 1
   _toggle_write_baseline true true
-  _toggle_set_flag "$key1" true
-  _toggle_set_flag "$key2" false
+  _config_set_field "$key1" true
+  _config_set_field "$key2" false
 }
 
 # Given a config with "rag.enabled" true and "distill.enabled" true
@@ -160,13 +146,13 @@ given_a_config_with_true_and_true() {
   local key1="${1:-}" key2="${2:-}"
   [ -n "$key1" ] && [ -n "$key2" ] || return 1
   _toggle_write_baseline true true
-  _toggle_set_flag "$key1" true
-  _toggle_set_flag "$key2" true
+  _config_set_field "$key1" true
+  _config_set_field "$key2" true
 }
 
 # And a snapshot of the config file's mtime and inode
 given_a_snapshot_of_the_config_file_s_mtime_and_inode() {
-  TG_SNAPSHOT="$(_toggle_stat_fingerprint "$(_toggle_config_path)")"
+  TG_SNAPSHOT="$(_toggle_stat_fingerprint "$(_config_path)")"
 }
 
 # Given there is no config file at "<path>"
@@ -181,7 +167,7 @@ given_there_is_no_config_file_at() {
 given_the_config_contains_an_unrelated_user_key_set_to_42() {
   local key="${1:-}"
   [ -n "$key" ] || return 1
-  _toggle_set_flag "$key" 42
+  _config_set_field "$key" 42
 }
 
 # And a "mv" stub on PATH that always exits non-zero
@@ -240,13 +226,13 @@ then_the_config_at_has_set_to_false() {
 then_the_config_has_set_to_true() {
   local key="${1:-}"
   [ -n "$key" ] || return 1
-  [ "$(jq -r --arg k "$key" 'getpath($k | split("."))' "$(_toggle_config_path)")" = "true" ]
+  [ "$(jq -r --arg k "$key" 'getpath($k | split("."))' "$(_config_path)")" = "true" ]
 }
 
 # And the config file's mtime and inode match the snapshot
 then_the_config_file_s_mtime_and_inode_match_the_snapshot() {
   local current
-  current="$(_toggle_stat_fingerprint "$(_toggle_config_path)")"
+  current="$(_toggle_stat_fingerprint "$(_config_path)")"
   [ "$current" = "$TG_SNAPSHOT" ]
 }
 
@@ -268,7 +254,7 @@ then_the_config_at_still_has_set_to_true() {
 then_the_config_still_has_set_to_42() {
   local key="${1:-}"
   [ -n "$key" ] || return 1
-  [ "$(jq -r --arg k "$key" 'getpath($k | split("."))' "$(_toggle_config_path)")" = "42" ]
+  [ "$(jq -r --arg k "$key" 'getpath($k | split("."))' "$(_config_path)")" = "42" ]
 }
 
 # And no ".tmp" artifact remains in "<dir>"
@@ -284,7 +270,7 @@ then_no_artifact_remains_in() {
 # And the config uses 2-space indentation
 then_the_config_uses_2_space_indentation() {
   local cfg
-  cfg="$(_toggle_config_path)"
+  cfg="$(_config_path)"
   # Two-space body lines ("  \"<key>\": ...") and four-space nested lines
   # ("    \"enabled\": ...") are both produced by `jq --indent 2`.
   grep -q '^  "' "$cfg" && grep -q '^    "enabled"' "$cfg"

--- a/tests/helpers/scratch.bash
+++ b/tests/helpers/scratch.bash
@@ -62,6 +62,11 @@ export VAULT
 PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export PLUGIN_ROOT
 
+_stat_fingerprint() {
+  if stat -f '%i-%m' "$1" 2>/dev/null; then return 0; fi
+  stat -c '%i-%Y' "$1"
+}
+
 assert_home_untouched() {
   local current
   current="$(_home_digest "$REAL_HOME")"

--- a/tests/integration/toggle.bats
+++ b/tests/integration/toggle.bats
@@ -56,17 +56,6 @@ _write_config_with_custom() {
 EOF
 }
 
-# Inode + mtime are captured together so "config unchanged" assertions can
-# prove both that the bytes did not change and that the file was not replaced
-# by a rename-in-place that preserved content but churned metadata.
-_stat_fingerprint() {
-  # macOS BSD stat vs. Linux GNU stat — use POSIX fallback syntax.
-  if stat -f '%i-%m' "$1" 2>/dev/null; then
-    return 0
-  fi
-  stat -c '%i-%Y' "$1"
-}
-
 # ---------------------------------------------------------------------------
 # Status
 # ---------------------------------------------------------------------------

--- a/tests/integration/toggle.bats
+++ b/tests/integration/toggle.bats
@@ -114,7 +114,6 @@ _stat_fingerprint() {
 @test "already_in_state: reports 'was already', exits 0, does NOT rewrite" {
   _write_config true true
   before="$(_stat_fingerprint "$CONFIG")"
-  sleep 1  # ensure any rewrite would produce a different mtime
   run "$TOGGLE" rag on
   [ "$status" -eq 0 ]
   [[ "$output" == *"rag.enabled was already true"* ]]

--- a/tests/integration/toggle.bats
+++ b/tests/integration/toggle.bats
@@ -1,0 +1,337 @@
+#!/usr/bin/env bats
+
+# tests/integration/toggle.bats — end-to-end coverage of vault-toggle.sh.
+#
+# Every scenario runs under the bats scratch harness (tests/helpers/scratch)
+# so $HOME is redirected to $BATS_TEST_TMPDIR/home and assert_home_untouched
+# verifies that the operator's real ~/.claude/obsidian-memory/ was never
+# touched during the run.
+#
+# Covers T007 in specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/tasks.md.
+
+setup() {
+  load '../helpers/scratch'
+
+  TOGGLE="$PLUGIN_ROOT/scripts/vault-toggle.sh"
+  export TOGGLE
+
+  CONFIG="$HOME/.claude/obsidian-memory/config.json"
+  export CONFIG
+
+  mkdir -p "$HOME/.claude/obsidian-memory"
+}
+
+teardown() {
+  assert_home_untouched
+}
+
+_write_config() {
+  # $1 = rag.enabled (true/false), $2 = distill.enabled (true/false)
+  cat > "$CONFIG" <<EOF
+{
+  "vaultPath": "$VAULT",
+  "rag": {
+    "enabled": $1
+  },
+  "distill": {
+    "enabled": $2
+  }
+}
+EOF
+}
+
+_write_config_with_custom() {
+  # $1 = rag.enabled, $2 = distill.enabled, emits an extra "customFoo": 42 key.
+  cat > "$CONFIG" <<EOF
+{
+  "vaultPath": "$VAULT",
+  "rag": {
+    "enabled": $1
+  },
+  "distill": {
+    "enabled": $2
+  },
+  "customFoo": 42
+}
+EOF
+}
+
+# Inode + mtime are captured together so "config unchanged" assertions can
+# prove both that the bytes did not change and that the file was not replaced
+# by a rename-in-place that preserved content but churned metadata.
+_stat_fingerprint() {
+  # macOS BSD stat vs. Linux GNU stat — use POSIX fallback syntax.
+  if stat -f '%i-%m' "$1" 2>/dev/null; then
+    return 0
+  fi
+  stat -c '%i-%Y' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+@test "status: prints both flags, exit 0" {
+  _write_config true false
+  run "$TOGGLE" status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rag.enabled: true"* ]]
+  [[ "$output" == *"distill.enabled: false"* ]]
+}
+
+@test "status_shorthand: no args is equivalent to 'status'" {
+  _write_config false true
+  before="$(_stat_fingerprint "$CONFIG")"
+  run "$TOGGLE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rag.enabled: false"* ]]
+  [[ "$output" == *"distill.enabled: true"* ]]
+  after="$(_stat_fingerprint "$CONFIG")"
+  [ "$before" = "$after" ]
+}
+
+# ---------------------------------------------------------------------------
+# Explicit set
+# ---------------------------------------------------------------------------
+
+@test "rag_off: flips rag.enabled true → false, exit 0, persists to disk" {
+  _write_config true true
+  run "$TOGGLE" rag off
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rag.enabled: true -> false"* ]]
+  [ "$(jq -r '.rag.enabled' "$CONFIG")" = "false" ]
+  [ "$(jq -r '.distill.enabled' "$CONFIG")" = "true" ]
+}
+
+@test "distill_on: flips distill.enabled false → true" {
+  _write_config true false
+  run "$TOGGLE" distill on
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"distill.enabled: false -> true"* ]]
+  [ "$(jq -r '.distill.enabled' "$CONFIG")" = "true" ]
+}
+
+@test "already_in_state: reports 'was already', exits 0, does NOT rewrite" {
+  _write_config true true
+  before="$(_stat_fingerprint "$CONFIG")"
+  sleep 1  # ensure any rewrite would produce a different mtime
+  run "$TOGGLE" rag on
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rag.enabled was already true"* ]]
+  after="$(_stat_fingerprint "$CONFIG")"
+  [ "$before" = "$after" ]
+}
+
+# ---------------------------------------------------------------------------
+# Flip (no explicit state)
+# ---------------------------------------------------------------------------
+
+@test "flip_true_to_false: 'distill' alone inverts the current value" {
+  _write_config true true
+  run "$TOGGLE" distill
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"distill.enabled: true -> false"* ]]
+  [ "$(jq -r '.distill.enabled' "$CONFIG")" = "false" ]
+}
+
+@test "flip_false_to_true: 'rag' alone inverts the current value" {
+  _write_config false true
+  run "$TOGGLE" rag
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rag.enabled: false -> true"* ]]
+  [ "$(jq -r '.rag.enabled' "$CONFIG")" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# Aliases (AC8)
+# ---------------------------------------------------------------------------
+
+@test "alias_on_variants: on|true|1|yes all set to true" {
+  local alias
+  for alias in on true 1 yes; do
+    _write_config false true
+    run "$TOGGLE" rag "$alias"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.rag.enabled' "$CONFIG")" = "true" ]
+  done
+}
+
+@test "alias_off_variants: off|false|0|no all set to false" {
+  local alias
+  for alias in off false 0 no; do
+    _write_config true true
+    run "$TOGGLE" rag "$alias"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.rag.enabled' "$CONFIG")" = "false" ]
+  done
+}
+
+@test "alias_case_insensitive: 'OFF' / 'True' resolve the same as lowercase" {
+  _write_config true true
+  run "$TOGGLE" rag OFF
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.rag.enabled' "$CONFIG")" = "false" ]
+
+  _write_config false true
+  run "$TOGGLE" rag True
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.rag.enabled' "$CONFIG")" = "true" ]
+}
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+@test "unknown_feature: foobar → stderr ERROR, exit 2, config unchanged" {
+  _write_config true true
+  before="$(_stat_fingerprint "$CONFIG")"
+  run "$TOGGLE" foobar on
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"ERROR: unknown feature 'foobar'"* ]] || [[ "$output" == *"ERROR: unknown feature 'foobar'"* ]]
+  after="$(_stat_fingerprint "$CONFIG")"
+  [ "$before" = "$after" ]
+}
+
+@test "unknown_state: 'rag maybe' → stderr ERROR, exit 2, config unchanged" {
+  _write_config true true
+  before="$(_stat_fingerprint "$CONFIG")"
+  run "$TOGGLE" rag maybe
+  [ "$status" -eq 2 ]
+  [[ "$stderr" == *"ERROR: unknown state 'maybe'"* ]] || [[ "$output" == *"ERROR: unknown state 'maybe'"* ]]
+  after="$(_stat_fingerprint "$CONFIG")"
+  [ "$before" = "$after" ]
+}
+
+@test "too_many_args: three positional args → usage, exit 2" {
+  _write_config true true
+  run "$TOGGLE" rag on extra
+  [ "$status" -eq 2 ]
+}
+
+@test "missing_config: no config file → stderr ERROR, exit 1, no file created" {
+  [ ! -e "$CONFIG" ]
+  run "$TOGGLE" rag on
+  [ "$status" -eq 1 ]
+  [[ "$stderr" == *"ERROR: config not found"* ]] || [[ "$output" == *"ERROR: config not found"* ]]
+  [[ "$stderr" == *"/obsidian-memory:setup"* ]] || [[ "$output" == *"/obsidian-memory:setup"* ]]
+  [ ! -e "$CONFIG" ]
+}
+
+# ---------------------------------------------------------------------------
+# Key preservation (T003)
+# ---------------------------------------------------------------------------
+
+@test "preserve_unrelated_keys: customFoo round-trips after a toggle" {
+  _write_config_with_custom true true
+  run "$TOGGLE" rag off
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.customFoo' "$CONFIG")" = "42" ]
+  [ "$(jq -r '.vaultPath' "$CONFIG")" = "$VAULT" ]
+  [ "$(jq -r '.rag.enabled' "$CONFIG")" = "false" ]
+  [ "$(jq -r '.distill.enabled' "$CONFIG")" = "true" ]
+}
+
+@test "preserve_2space_indent: rewritten config still uses 2-space indent" {
+  _write_config true true
+  run "$TOGGLE" rag off
+  [ "$status" -eq 0 ]
+  # A 2-space-indented body has at least one "  \"" line.
+  grep -q '^  "' "$CONFIG"
+  # And the nested boolean is indented with 4 spaces, not 1 or a tab.
+  grep -q '^    "enabled":' "$CONFIG"
+}
+
+@test "missing_feature_stanza: jq creates the stanza; other keys survive" {
+  # Config has NO "distill" key at all.
+  cat > "$CONFIG" <<EOF
+{
+  "vaultPath": "$VAULT",
+  "rag": {
+    "enabled": true
+  }
+}
+EOF
+  run "$TOGGLE" distill on
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.distill.enabled' "$CONFIG")" = "true" ]
+  [ "$(jq -r '.rag.enabled' "$CONFIG")" = "true" ]
+  [ "$(jq -r '.vaultPath' "$CONFIG")" = "$VAULT" ]
+}
+
+@test "missing_feature_stanza_status: unset flag reports as true" {
+  cat > "$CONFIG" <<EOF
+{
+  "vaultPath": "$VAULT",
+  "rag": {
+    "enabled": true
+  }
+}
+EOF
+  before="$(_stat_fingerprint "$CONFIG")"
+  run "$TOGGLE" status
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"distill.enabled: true"* ]]
+  after="$(_stat_fingerprint "$CONFIG")"
+  [ "$before" = "$after" ]
+}
+
+# ---------------------------------------------------------------------------
+# Atomic-write invariant
+# ---------------------------------------------------------------------------
+
+# Replace `mv` on PATH with a stub that always fails. The script should detect
+# the failure, exit 1, and leave the original config untouched byte-for-byte.
+# The EXIT trap clears the .tmp.$$ droppings.
+@test "atomic_write_mv_fails: original config untouched when mv fails" {
+  _write_config_with_custom true true
+  before_bytes="$(cksum < "$CONFIG")"
+
+  local bindir="$BATS_TEST_TMPDIR/failbin"
+  mkdir -p "$bindir"
+  # Symlink every real executable into the stub bindir so bash, jq, cksum,
+  # stat, grep, etc. still resolve.
+  local d f name
+  local IFS_SAVED="$IFS"
+  IFS=':'
+  for d in $PATH; do
+    [ -d "$d" ] || continue
+    for f in "$d"/*; do
+      [ -x "$f" ] || continue
+      name="$(basename "$f")"
+      [ -e "$bindir/$name" ] && continue
+      ln -s "$f" "$bindir/$name" 2>/dev/null || true
+    done
+  done
+  IFS="$IFS_SAVED"
+
+  rm -f "$bindir/mv"
+  cat > "$bindir/mv" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "$bindir/mv"
+
+  PATH="$bindir" run "$TOGGLE" rag off
+  [ "$status" -eq 1 ]
+
+  after_bytes="$(cksum < "$CONFIG")"
+  [ "$before_bytes" = "$after_bytes" ]
+  [ "$(jq -r '.rag.enabled' "$CONFIG")" = "true" ]
+  [ "$(jq -r '.customFoo' "$CONFIG")" = "42" ]
+
+  # EXIT trap cleaned up any temp droppings.
+  run bash -c "ls '$HOME/.claude/obsidian-memory/'*.tmp.* 2>/dev/null"
+  [ "$status" -ne 0 ] || [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Shellcheck gate
+# ---------------------------------------------------------------------------
+
+@test "shellcheck_clean: scripts/vault-toggle.sh passes shellcheck" {
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    skip "shellcheck not installed"
+  fi
+  run shellcheck "$PLUGIN_ROOT/scripts/vault-toggle.sh"
+  [ "$status" -eq 0 ]
+}

--- a/tests/run-bdd.sh
+++ b/tests/run-bdd.sh
@@ -38,6 +38,8 @@ _step_file_for() {
     feature-manual-distill-skill)                     printf '%s' "$STEPS_DIR/manual-distill.sh" ;;
     feature-doctor-health-check-skill)                printf '%s' "$STEPS_DIR/doctor.sh" ;;
     feature-add-obsidian-memory-teardown-skill)       printf '%s' "$STEPS_DIR/teardown.sh" ;;
+    feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags) \
+                                                      printf '%s' "$STEPS_DIR/toggle.sh" ;;
     feature-set-up-bats-core-cucumber-shell-test-harness) printf '%s' "$STEPS_DIR/harness.sh" ;;
     example)                                          printf '%s' "$STEPS_DIR/example.sh" ;;
     *)

--- a/tests/run-bdd.sh
+++ b/tests/run-bdd.sh
@@ -245,6 +245,9 @@ _run_feature() {
         continue
         ;;
       'Scenario Outline:'*|Examples:*)
+        if [ "$have_scenario" = 1 ]; then
+          _dispatch_scenario "$feature" "$current_name" "$steps_file" "$bg_steps" "$current_steps"
+        fi
         _log_err "warning: Scenario Outline / Examples not supported in $feature; skipping"
         in_bg=0
         have_scenario=0


### PR DESCRIPTION
## Summary

Closes #4

Adds the `/obsidian-memory:toggle` skill — a one-command way to flip `rag.enabled` and `distill.enabled` in `~/.claude/obsidian-memory/config.json` without hand-editing JSON.

- `toggle <feature> on|off` — set the flag explicitly
- `toggle <feature>` — flip the current value
- `toggle status` (or no args) — read current state of both flags
- Atomic writes via temp-file + `mv`; config never left partially written
- Feature whitelist: `rag`, `distill`; unknown names exit non-zero with a clear message
- Missing config reports a clean error pointing to `/obsidian-memory:setup`

## Spec

- [Requirements](specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/requirements.md)
- [Design](specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/design.md)
- [Tasks](specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/tasks.md)
- [BDD Scenarios](specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/feature.gherkin)
- [Verification Report](specs/feature-add-obsidian-memory-toggle-skill-for-rag-distill-enable-flags/verification/report.md)

## Acceptance Criteria

- [x] AC1: Enable/disable flips flag and reports previous and new value
- [x] AC2: Toggle without explicit state flips the current value
- [x] AC3: Status read-out prints both flags without modifying config
- [x] AC4: Unknown feature name errors cleanly (exit non-zero, config unchanged)
- [x] AC5: Missing config is a clean error, not a crash
- [x] AC6: Writes are atomic (temp-file + `mv`)

## Version Bump

`0.2.0` → `0.3.0` (minor — `enhancement` label)