### PR TITLE
feat(distill): make distillation template configurable

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -337,6 +337,8 @@ om_resolve_distill_template() {
     fi
     printf '[vault-distill.sh] projects.overrides.%s.distill.template_path=%s unreadable; falling back to default template\n' \
       "$slug" "$override_path" >&2
+    # Suppress the global warning when the override already produced a log line
+    # — one warning per invocation is the specified behavior (AC3).
     logged=1
   fi
 
@@ -352,7 +354,6 @@ om_resolve_distill_template() {
   fi
 
   printf '%s/templates/default-distillation.md' "$(om_plugin_root)"
-  return 0
 }
 
 # om_describe_distill_template <slug> — echoes a doctor-oriented descriptor

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -169,13 +169,44 @@ om_project_allowed() {
   esac
 }
 
-# --- Template resolution, frontmatter split, variable substitution (issue #7) ---
+# --- Template resolution, frontmatter split, variable substitution ---
 
 # om_plugin_root — echoes the absolute path to the plugin root. Derived from
 # this file's location (scripts/_common.sh → plugin-root). Keeps the template
 # path resolution independent of the caller's $0.
 om_plugin_root() {
   ( cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )
+}
+
+# _om_resolve_to_home <path> — absolute-or-$HOME-relative path resolver.
+# Echoes the input unchanged if it begins with `/`; otherwise prefixes $HOME.
+# Empty input returns empty (caller treats that as "not configured").
+_om_resolve_to_home() {
+  local raw="${1-}"
+  [ -n "$raw" ] || return 0
+  case "$raw" in
+    /*) printf '%s' "$raw" ;;
+    *)  printf '%s/%s' "$HOME" "$raw" ;;
+  esac
+}
+
+# _om_read_distill_template_paths <slug> — prints two newline-separated fields:
+# the per-project override path (or empty) and the global path (or empty).
+# Both are already $HOME-resolved. Silent on any jq / config error.
+_om_read_distill_template_paths() {
+  local slug="${1-}"
+  local override_raw="" global_raw=""
+  if [ -r "$CONFIG" ] && command -v jq >/dev/null 2>&1; then
+    { IFS= read -r override_raw; IFS= read -r global_raw; } < <(
+      jq -r --arg slug "$slug" '
+        (.projects.overrides[$slug].distill.template_path // ""),
+        (.distill.template_path // "")
+      ' "$CONFIG" 2>/dev/null
+    )
+  fi
+  printf '%s\n%s\n' \
+    "$(_om_resolve_to_home "$override_raw")" \
+    "$(_om_resolve_to_home "$global_raw")"
 }
 
 # om_render <text> — substitute the six whitelisted template tokens in <text>.
@@ -293,54 +324,34 @@ om_split_frontmatter() {
 # Returns 0 always — the bundled default is an install-time invariant.
 om_resolve_distill_template() {
   local slug="${1-}"
-  local bundled override_path global_path
-  bundled="$(om_plugin_root)/templates/default-distillation.md"
+  local override_path global_path
+  { IFS= read -r override_path; IFS= read -r global_path; } < <(
+    _om_read_distill_template_paths "$slug"
+  )
 
-  override_path=""
-  global_path=""
-  if [ -r "$CONFIG" ] && command -v jq >/dev/null 2>&1; then
-    { IFS= read -r override_path; IFS= read -r global_path; } < <(
-      jq -r --arg slug "$slug" '
-        (.projects.overrides[$slug].distill.template_path // ""),
-        (.distill.template_path // "")
-      ' "$CONFIG" 2>/dev/null
-    )
-  fi
-
-  _om_resolve_path() {
-    local raw="$1"
-    [ -n "$raw" ] || return 1
-    case "$raw" in
-      /*) printf '%s' "$raw" ;;
-      *)  printf '%s/%s' "$HOME" "$raw" ;;
-    esac
-  }
-
-  local path logged=0
+  local logged=0
   if [ -n "$override_path" ]; then
-    path="$(_om_resolve_path "$override_path")"
-    if [ -r "$path" ] && [ -s "$path" ]; then
-      printf '%s' "$path"
+    if [ -r "$override_path" ] && [ -s "$override_path" ]; then
+      printf '%s' "$override_path"
       return 0
     fi
     printf '[vault-distill.sh] projects.overrides.%s.distill.template_path=%s unreadable; falling back to default template\n' \
-      "$slug" "$path" >&2
+      "$slug" "$override_path" >&2
     logged=1
   fi
 
   if [ -n "$global_path" ]; then
-    path="$(_om_resolve_path "$global_path")"
-    if [ -r "$path" ] && [ -s "$path" ]; then
-      printf '%s' "$path"
+    if [ -r "$global_path" ] && [ -s "$global_path" ]; then
+      printf '%s' "$global_path"
       return 0
     fi
     if [ "$logged" -eq 0 ]; then
       printf '[vault-distill.sh] distill.template_path=%s unreadable; falling back to default template\n' \
-        "$path" >&2
+        "$global_path" >&2
     fi
   fi
 
-  printf '%s' "$bundled"
+  printf '%s/templates/default-distillation.md' "$(om_plugin_root)"
   return 0
 }
 
@@ -355,40 +366,26 @@ om_resolve_distill_template() {
 #   configured but unreadable — falling back to default
 om_describe_distill_template() {
   local slug="${1-}"
-  local override_path="" global_path=""
-  if [ -r "$CONFIG" ] && command -v jq >/dev/null 2>&1; then
-    { IFS= read -r override_path; IFS= read -r global_path; } < <(
-      jq -r --arg slug "$slug" '
-        (.projects.overrides[$slug].distill.template_path // ""),
-        (.distill.template_path // "")
-      ' "$CONFIG" 2>/dev/null
-    )
-  fi
+  local override_path global_path
+  { IFS= read -r override_path; IFS= read -r global_path; } < <(
+    _om_read_distill_template_paths "$slug"
+  )
 
-  local path
   if [ -n "$override_path" ]; then
-    case "$override_path" in
-      /*) path="$override_path" ;;
-      *)  path="$HOME/$override_path" ;;
-    esac
-    if [ -r "$path" ] && [ -s "$path" ]; then
-      printf 'project-override(%s): %s' "$slug" "$path"
-      return 0
+    if [ -r "$override_path" ] && [ -s "$override_path" ]; then
+      printf 'project-override(%s): %s' "$slug" "$override_path"
+    else
+      printf 'configured but unreadable — falling back to default'
     fi
-    printf 'configured but unreadable — falling back to default'
     return 0
   fi
 
   if [ -n "$global_path" ]; then
-    case "$global_path" in
-      /*) path="$global_path" ;;
-      *)  path="$HOME/$global_path" ;;
-    esac
-    if [ -r "$path" ] && [ -s "$path" ]; then
-      printf 'global: %s' "$path"
-      return 0
+    if [ -r "$global_path" ] && [ -s "$global_path" ]; then
+      printf 'global: %s' "$global_path"
+    else
+      printf 'configured but unreadable — falling back to default'
     fi
-    printf 'configured but unreadable — falling back to default'
     return 0
   fi
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -168,3 +168,229 @@ om_project_allowed() {
     *) return 0 ;;
   esac
 }
+
+# --- Template resolution, frontmatter split, variable substitution (issue #7) ---
+
+# om_plugin_root — echoes the absolute path to the plugin root. Derived from
+# this file's location (scripts/_common.sh → plugin-root). Keeps the template
+# path resolution independent of the caller's $0.
+om_plugin_root() {
+  ( cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd )
+}
+
+# om_render <text> — substitute the six whitelisted template tokens in <text>.
+#
+# Reads substitution values from the caller's environment:
+#   SLUG            → {{project_slug}}
+#   NOW_DATE        → {{date}}
+#   NOW_TIME        → {{time}}
+#   SESSION_ID      → {{session_id}}
+#   TRANSCRIPT      → {{transcript_path}}
+#   CONVO           → {{transcript}}
+#
+# Uses a single `jq -Rn` invocation with chained `gsub` calls. Non-whitelisted
+# `{{…}}` tokens and any shell-looking syntax (`$VAR`, backticks, `$(…)`,
+# `${…}`) pass through literally — jq never evaluates template content as
+# shell. If jq fails (rare: filesystem error), echoes the input unchanged and
+# returns 0 so a substitution glitch never blocks the hook.
+om_render() {
+  local text="${1-}"
+  local rendered
+  if ! rendered="$(
+    jq -Rrn \
+      --arg text          "$text" \
+      --arg project_slug  "${SLUG-}" \
+      --arg date          "${NOW_DATE-}" \
+      --arg time          "${NOW_TIME-}" \
+      --arg session_id    "${SESSION_ID-}" \
+      --arg transcript_path "${TRANSCRIPT-}" \
+      --arg transcript    "${CONVO-}" \
+      '$text
+       | gsub("\\{\\{project_slug\\}\\}";    $project_slug)
+       | gsub("\\{\\{date\\}\\}";            $date)
+       | gsub("\\{\\{time\\}\\}";            $time)
+       | gsub("\\{\\{session_id\\}\\}";      $session_id)
+       | gsub("\\{\\{transcript_path\\}\\}"; $transcript_path)
+       | gsub("\\{\\{transcript\\}\\}";      $transcript)' 2>/dev/null
+  )"; then
+    printf '%s' "$text"
+    return 0
+  fi
+  printf '%s' "$rendered"
+}
+
+# om_split_frontmatter <text> — split <text> into (optional) YAML frontmatter
+# and body regions, joined by a single 0x1E (record separator) byte:
+#   <frontmatter><0x1E><body>
+#
+# Detection: the first non-blank line must be exactly `---`, AND a subsequent
+# line must also be exactly `---`. The frontmatter region is inclusive of both
+# `---` lines; the body begins on the line after the closing `---`. A
+# malformed template (opening `---` without a closing `---`) is treated as
+# having no frontmatter — the whole input falls into the body region.
+#
+# Implementation is POSIX awk — no bash 4+ features.
+om_split_frontmatter() {
+  local text="${1-}"
+  printf '%s' "$text" | awk '
+    BEGIN { state = "scan"; fm = ""; body = "" }
+    {
+      if (state == "scan") {
+        if ($0 ~ /^[[:space:]]*$/) {
+          fm = fm $0 "\n"
+          next
+        }
+        if ($0 == "---") {
+          fm = fm $0 "\n"
+          state = "fm"
+          next
+        }
+        state = "body"
+        body = $0 "\n"
+        next
+      }
+      if (state == "fm") {
+        fm = fm $0 "\n"
+        if ($0 == "---") {
+          state = "after_fm"
+        }
+        next
+      }
+      if (state == "after_fm" || state == "body") {
+        body = body $0 "\n"
+        state = "body"
+        next
+      }
+    }
+    END {
+      if (state == "after_fm" || state == "body") {
+        # Either a full FM was captured (after_fm) and body may be empty, or we
+        # landed in body directly (no FM). Both emit fm<0x1E>body.
+        printf "%s\x1e%s", fm, body
+      } else {
+        # state == "scan" (blank-only input) or state == "fm" (unterminated FM)
+        # → treat as no-frontmatter, body = full input.
+        printf "\x1e%s", fm
+      }
+    }
+  '
+}
+
+# om_resolve_distill_template <slug> — echoes the absolute path to the
+# distillation template that should be used for <slug>.
+#
+# Resolution order:
+#   1. projects.overrides.<slug>.distill.template_path
+#   2. distill.template_path
+#   3. <plugin-root>/templates/default-distillation.md
+#
+# A configured path is used only when [ -r <path> ] && [ -s <path> ] (readable
+# regular file, non-empty). When a configured path fails that check, exactly
+# one stderr line is emitted identifying which scope held the bad path, and
+# resolution falls through to the next tier. Relative paths in config are
+# resolved against $HOME.
+#
+# Returns 0 always — the bundled default is an install-time invariant.
+om_resolve_distill_template() {
+  local slug="${1-}"
+  local bundled override_path global_path
+  bundled="$(om_plugin_root)/templates/default-distillation.md"
+
+  override_path=""
+  global_path=""
+  if [ -r "$CONFIG" ] && command -v jq >/dev/null 2>&1; then
+    { IFS= read -r override_path; IFS= read -r global_path; } < <(
+      jq -r --arg slug "$slug" '
+        (.projects.overrides[$slug].distill.template_path // ""),
+        (.distill.template_path // "")
+      ' "$CONFIG" 2>/dev/null
+    )
+  fi
+
+  _om_resolve_path() {
+    local raw="$1"
+    [ -n "$raw" ] || return 1
+    case "$raw" in
+      /*) printf '%s' "$raw" ;;
+      *)  printf '%s/%s' "$HOME" "$raw" ;;
+    esac
+  }
+
+  local path logged=0
+  if [ -n "$override_path" ]; then
+    path="$(_om_resolve_path "$override_path")"
+    if [ -r "$path" ] && [ -s "$path" ]; then
+      printf '%s' "$path"
+      return 0
+    fi
+    printf '[vault-distill.sh] projects.overrides.%s.distill.template_path=%s unreadable; falling back to default template\n' \
+      "$slug" "$path" >&2
+    logged=1
+  fi
+
+  if [ -n "$global_path" ]; then
+    path="$(_om_resolve_path "$global_path")"
+    if [ -r "$path" ] && [ -s "$path" ]; then
+      printf '%s' "$path"
+      return 0
+    fi
+    if [ "$logged" -eq 0 ]; then
+      printf '[vault-distill.sh] distill.template_path=%s unreadable; falling back to default template\n' \
+        "$path" >&2
+    fi
+  fi
+
+  printf '%s' "$bundled"
+  return 0
+}
+
+# om_describe_distill_template <slug> — echoes a doctor-oriented descriptor
+# string for the active template, without emitting the stderr warning
+# om_resolve_distill_template would produce on an unreadable configured path.
+#
+# Returns one of:
+#   default (bundled)
+#   global: <path>
+#   project-override(<slug>): <path>
+#   configured but unreadable — falling back to default
+om_describe_distill_template() {
+  local slug="${1-}"
+  local override_path="" global_path=""
+  if [ -r "$CONFIG" ] && command -v jq >/dev/null 2>&1; then
+    { IFS= read -r override_path; IFS= read -r global_path; } < <(
+      jq -r --arg slug "$slug" '
+        (.projects.overrides[$slug].distill.template_path // ""),
+        (.distill.template_path // "")
+      ' "$CONFIG" 2>/dev/null
+    )
+  fi
+
+  local path
+  if [ -n "$override_path" ]; then
+    case "$override_path" in
+      /*) path="$override_path" ;;
+      *)  path="$HOME/$override_path" ;;
+    esac
+    if [ -r "$path" ] && [ -s "$path" ]; then
+      printf 'project-override(%s): %s' "$slug" "$path"
+      return 0
+    fi
+    printf 'configured but unreadable — falling back to default'
+    return 0
+  fi
+
+  if [ -n "$global_path" ]; then
+    case "$global_path" in
+      /*) path="$global_path" ;;
+      *)  path="$HOME/$global_path" ;;
+    esac
+    if [ -r "$path" ] && [ -s "$path" ]; then
+      printf 'global: %s' "$path"
+      return 0
+    fi
+    printf 'configured but unreadable — falling back to default'
+    return 0
+  fi
+
+  printf 'default (bundled)'
+}

--- a/scripts/vault-distill.sh
+++ b/scripts/vault-distill.sh
@@ -90,12 +90,6 @@ CONVO="$(
 
 TEMPLATE_PATH="$(om_resolve_distill_template "$SLUG")"
 TMPL_RAW="$(cat "$TEMPLATE_PATH" 2>/dev/null)"
-if [ -z "$TMPL_RAW" ]; then
-  # Narrow race: the resolved path was readable/non-empty when checked but
-  # gone / truncated by the time we cat'd it. Fall back to the bundled default.
-  TEMPLATE_PATH="$(om_plugin_root)/templates/default-distillation.md"
-  TMPL_RAW="$(cat "$TEMPLATE_PATH" 2>/dev/null)"
-fi
 
 SPLIT="$(om_split_frontmatter "$TMPL_RAW"; printf x)"
 SPLIT="${SPLIT%x}"

--- a/scripts/vault-distill.sh
+++ b/scripts/vault-distill.sh
@@ -54,7 +54,7 @@ SLUG="$(om_slug "$CWD")"
 [ -n "$SLUG" ] || SLUG="unknown"
 
 NOW_STAMP="$(date -u +%Y-%m-%d-%H%M%S)"
-NOW_DATE="$(date -u +%Y-%m-%d)"
+NOW_DATE="${NOW_STAMP%-*}"
 NOW_TIME="${NOW_STAMP##*-}"
 NOW_TIME="${NOW_TIME:0:2}:${NOW_TIME:2:2}:${NOW_TIME:4:2}"
 
@@ -89,7 +89,7 @@ CONVO="$(
 [ -n "$CONVO" ] || exit 0
 
 TEMPLATE_PATH="$(om_resolve_distill_template "$SLUG")"
-TMPL_RAW="$(cat "$TEMPLATE_PATH" 2>/dev/null)"
+TMPL_RAW="$(cat "$TEMPLATE_PATH")"
 
 SPLIT="$(om_split_frontmatter "$TMPL_RAW"; printf x)"
 SPLIT="${SPLIT%x}"

--- a/scripts/vault-distill.sh
+++ b/scripts/vault-distill.sh
@@ -54,8 +54,7 @@ SLUG="$(om_slug "$CWD")"
 [ -n "$SLUG" ] || SLUG="unknown"
 
 NOW_STAMP="$(date -u +%Y-%m-%d-%H%M%S)"
-NOW_DATE="${NOW_STAMP%-*}"
-NOW_DATE="${NOW_DATE%-*}"
+NOW_DATE="$(date -u +%Y-%m-%d)"
 NOW_TIME="${NOW_STAMP##*-}"
 NOW_TIME="${NOW_TIME:0:2}:${NOW_TIME:2:2}:${NOW_TIME:4:2}"
 
@@ -89,46 +88,45 @@ CONVO="$(
 )"
 [ -n "$CONVO" ] || exit 0
 
-PROMPT="You are distilling a Claude Code session transcript into a concise Obsidian note.
+TEMPLATE_PATH="$(om_resolve_distill_template "$SLUG")"
+TMPL_RAW="$(cat "$TEMPLATE_PATH" 2>/dev/null)"
+if [ -z "$TMPL_RAW" ]; then
+  # Narrow race: the resolved path was readable/non-empty when checked but
+  # gone / truncated by the time we cat'd it. Fall back to the bundled default.
+  TEMPLATE_PATH="$(om_plugin_root)/templates/default-distillation.md"
+  TMPL_RAW="$(cat "$TEMPLATE_PATH" 2>/dev/null)"
+fi
 
-Output ONLY the note body in Markdown. No preamble. No outer code fences.
+SPLIT="$(om_split_frontmatter "$TMPL_RAW"; printf x)"
+SPLIT="${SPLIT%x}"
+FM_RAW="${SPLIT%%$'\x1e'*}"
+BODY_RAW="${SPLIT#*$'\x1e'}"
 
-Include these sections (omit any that would be empty):
-
-## Summary
-Two or three sentences describing what the session accomplished.
-
-## Decisions
-Notable choices and the reasoning behind them.
-
-## Patterns & Gotchas
-Specific file paths, commands, identifiers, or non-obvious constraints worth remembering.
-
-## Open Threads
-What is unfinished or should be picked up next.
-
-## Tags
-A single space-separated line starting with #project/${SLUG}, plus 3–5 topical tags.
-
-Use Obsidian [[wiki-links]] for salient entities (files, functions, concepts). Cap the note at ~500 words.
-
-TRANSCRIPT:
-
-${CONVO}"
+FM_OUT="$(om_render "$FM_RAW")"
+PROMPT="$(om_render "$BODY_RAW")"
 
 # CLAUDECODE="" avoids the "Cannot be launched inside another Claude Code session" guard.
 NOTE_BODY="$(CLAUDECODE="" claude -p "$PROMPT" 2>/dev/null)"
 
 {
-  printf -- '---\n'
-  printf 'date: %s\n' "$NOW_DATE"
-  printf 'time: %s\n' "$NOW_TIME"
-  printf 'session_id: %s\n' "$SESSION_ID"
-  printf 'project: %s\n' "$SLUG"
-  printf 'cwd: %s\n' "$CWD"
-  printf 'end_reason: %s\n' "$REASON"
-  printf 'source: claude-code\n'
-  printf -- '---\n\n'
+  if [ -n "$FM_OUT" ]; then
+    # Strip trailing newlines so the emitted "\n\n" produces exactly one blank
+    # line between the frontmatter and the body (AC5).
+    while [ "${FM_OUT: -1}" = $'\n' ]; do
+      FM_OUT="${FM_OUT%$'\n'}"
+    done
+    printf '%s\n\n' "$FM_OUT"
+  else
+    printf -- '---\n'
+    printf 'date: %s\n' "$NOW_DATE"
+    printf 'time: %s\n' "$NOW_TIME"
+    printf 'session_id: %s\n' "$SESSION_ID"
+    printf 'project: %s\n' "$SLUG"
+    printf 'cwd: %s\n' "$CWD"
+    printf 'end_reason: %s\n' "$REASON"
+    printf 'source: claude-code\n'
+    printf -- '---\n\n'
+  fi
   if [ -n "$NOTE_BODY" ]; then
     printf '%s\n' "$NOTE_BODY"
   else

--- a/scripts/vault-doctor.sh
+++ b/scripts/vault-doctor.sh
@@ -9,6 +9,13 @@ set -u
 
 # shellcheck disable=SC2329  # invoked indirectly by the ERR trap
 log_err() { printf '[%s] %s\n' "$(basename "$0")" "$*" >&2; }
+
+# Source the shared helpers (pulls in om_describe_distill_template, om_slug,
+# etc.). _common.sh installs its own `trap 'exit 0' ERR` for hook-safety —
+# doctor re-installs its own ERR trap immediately after so an unexpected
+# failure still exits 1 (doctor's contract) instead of 0 (hook contract).
+# shellcheck source=scripts/_common.sh
+. "$(dirname "$0")/_common.sh"
 trap 'log_err "failed at line $LINENO"; exit 1' ERR
 
 CONFIG="${HOME}/.claude/obsidian-memory/config.json"
@@ -221,6 +228,21 @@ probe_scope_mode() {
   fi
 }
 
+probe_distill_template() {
+  # Reports the active distillation template as an info line. Runs regardless
+  # of distill.enabled — a mis-configured template_path is worth surfacing
+  # even while the feature is toggled off.
+  if [ "$_config_readable" -ne 1 ] || [ "$_jq_available" -ne 1 ]; then
+    _record "distill_template" "info" "cannot read — config or jq missing"
+    return
+  fi
+  local slug descriptor
+  slug="$(om_slug "${PWD:-$HOME}")"
+  [ -n "$slug" ] || slug="unknown"
+  descriptor="$(om_describe_distill_template "$slug")"
+  _record "distill_template" "info" "$descriptor"
+}
+
 probe_ripgrep() {
   if command -v rg >/dev/null 2>&1; then
     _record "ripgrep" "info" "$(command -v rg)"
@@ -409,6 +431,7 @@ main() {
   probe_flag_enabled rag
   probe_flag_enabled distill
   probe_scope_mode
+  probe_distill_template
   probe_ripgrep
   probe_mcp
 

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -51,6 +51,7 @@ The script itself is read-only: no `>`, `>>`, `mv`, `rm`, `ln`, or `mkdir` anywh
 | `rag_enabled` | ok / fail | `run /obsidian-memory:toggle rag on` |
 | `distill_enabled` | ok / fail | `run /obsidian-memory:toggle distill on` |
 | `scope_mode` | info | (informational; reports `projects.mode` and excluded/allowed counts — adjust with `/obsidian-memory:scope`) |
+| `distill_template` | info | (informational; reports the active distillation template — `default (bundled)`, `global: <path>`, `project-override(<slug>): <path>`, or `configured but unreadable — falling back to default`. Configure via `distill.template_path` in `~/.claude/obsidian-memory/config.json`.) |
 | `ripgrep` | info | (optional; vault-rag.sh falls back to POSIX `grep -r`) |
 | `mcp` | info | (optional; Obsidian MCP server registration) |
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -114,6 +114,62 @@ Print a summary:
 - MCP registration status
 - Missing dependencies (if any)
 
+## Customizing the distillation template
+
+The distillation hook (`vault-distill.sh`) drives `claude -p` with a Markdown template. By default it ships a bundled template at `<plugin-root>/templates/default-distillation.md` that produces the v0.1 **Summary / Decisions / Patterns & Gotchas / Open Threads / Tags** layout. To customize the layout, copy the bundled file and point config at the copy:
+
+```bash
+mkdir -p "$HOME/.claude/obsidian-memory/templates"
+cp "<plugin-root>/templates/default-distillation.md" \
+   "$HOME/.claude/obsidian-memory/templates/my-template.md"
+$EDITOR "$HOME/.claude/obsidian-memory/templates/my-template.md"
+```
+
+Then add `distill.template_path` to `~/.claude/obsidian-memory/config.json`:
+
+```json
+{
+  "distill": { "enabled": true, "template_path": "/Users/me/.claude/obsidian-memory/templates/my-template.md" }
+}
+```
+
+### Template variables
+
+Only these six `{{…}}` tokens are substituted — everything else passes through verbatim:
+
+| Token | Value |
+|---|---|
+| `{{project_slug}}` | `[a-z0-9-]` slug derived from the session's `cwd` |
+| `{{date}}` | UTC date (`YYYY-MM-DD`) at session end |
+| `{{time}}` | UTC time (`HH:MM:SS`) at session end |
+| `{{session_id}}` | Claude Code session id from the hook payload |
+| `{{transcript_path}}` | absolute path to the JSONL transcript |
+| `{{transcript}}` | the extracted user+assistant conversation (~200 KB cap) |
+
+`$VAR`, `${VAR}`, backticks, and `$(…)` in the template are **never expanded** — substitution is literal-only (jq `gsub`), so templates cannot trigger shell execution even if sourced from elsewhere.
+
+### Optional YAML frontmatter
+
+If the template begins with a `---` delimited YAML frontmatter block, the hook emits **that** block (after variable substitution) as the note's frontmatter and skips its default seven-field block. Anything after the closing `---` is the distillation prompt body.
+
+### Per-project overrides
+
+To use a different template for a specific project, add `projects.overrides.<slug>.distill.template_path` — it takes precedence over the global `distill.template_path` for that slug. For example:
+
+```json
+{
+  "projects": {
+    "overrides": {
+      "widgets": {
+        "distill": { "template_path": "/Users/me/.claude/obsidian-memory/templates/work-note.md" }
+      }
+    }
+  }
+}
+```
+
+If a configured path is missing, unreadable, or empty, the hook logs one stderr line and falls back to the bundled default — the session note is never lost. Use `/obsidian-memory:doctor` to see which template is active for the current project.
+
 ## Error states
 
 | Condition | Behavior |

--- a/specs/feature-make-distillation-template-configurable/design.md
+++ b/specs/feature-make-distillation-template-configurable/design.md
@@ -1,0 +1,259 @@
+# Design: Configurable distillation template
+
+**Issues**: #7
+**Date**: 2026-04-22
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## Overview
+
+This design adds a single new seam to `scripts/vault-distill.sh`: the distillation prompt is no longer hardcoded — it is loaded from a Markdown template file, resolved in a deterministic order (per-project override > global `distill.template_path` > bundled default), variable-substituted via `jq gsub`, and optionally parsed for YAML frontmatter that the hook emits verbatim into the output file.
+
+The change is deliberately localized. Template loading, variable substitution, and frontmatter extraction become three new helper functions in `scripts/_common.sh` (where the existing config / slug / policy helpers already live). The hook body loses 20 lines of inline prompt construction and gains 4 lines of helper calls. A new top-level directory, `templates/`, ships a single file (`default-distillation.md`) that is the sole source of truth for the v0.1 layout — the current hardcoded prompt string is *removed*, not duplicated, to prevent drift between "the default" and "the default template."
+
+The design rejects three tempting but inferior alternatives: (1) `envsubst` (unsafe — expands any `$VAR` the template contains), (2) bash `${var//pattern/replacement}` inside a heredoc (macOS bash 3.2 compatibility risk and requires escaping), and (3) a Mustache-style Python/Node helper (new dependency, violates `steering/tech.md` stack constraints). `jq --rawfile | gsub` is the only approach that is both in-stack and provably shell-safe — the template content is read into a jq string and never reaches a shell interpreter.
+
+---
+
+## Architecture
+
+### Component Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Claude Code SessionEnd event                   │
+└──────────────────────────────┬──────────────────────────────────┘
+                               │  (payload JSON on stdin)
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                   scripts/vault-distill.sh                       │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 1. om_load_config distill  (existing)                     │  │
+│  │ 2. om_read_payload         (existing)                     │  │
+│  │ 3. Per-project scope gate  (existing, from #6)            │  │
+│  │ 4. Transcript size guard   (existing)                     │  │
+│  │ 5. Slug + timestamp derivation (existing)                 │  │
+│  │ 6. Extract CONVO via jq    (existing)                     │  │
+│  │                                                            │  │
+│  │ === NEW in #7: ============================================= │  │
+│  │ 7. template_path = om_resolve_distill_template "$SLUG"     │  │
+│  │ 8. tmpl_raw      = cat "$template_path" (or default file)  │  │
+│  │ 9. (fm, body)    = om_split_frontmatter "$tmpl_raw"        │  │
+│  │ 10. fm_out       = om_render "$fm"   (jq gsub)             │  │
+│  │ 11. prompt_out   = om_render "$body" (jq gsub)             │  │
+│  │ === /NEW =================================================== │  │
+│  │                                                            │  │
+│  │ 12. NOTE_BODY = CLAUDECODE="" claude -p "$prompt_out"      │  │
+│  │ 13. Emit file:  fm_out (or default frontmatter) + NOTE_BODY│  │
+│  │ 14. Update Index.md (existing)                             │  │
+│  └───────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+         │                           │
+         ▼                           ▼
+┌──────────────────────┐    ┌──────────────────────────┐
+│  scripts/_common.sh  │    │  templates/              │
+│  (new helpers)       │    │    default-distillation  │
+│  - om_resolve_...    │    │    .md                   │
+│  - om_split_fm       │    │  (FR4 — visible file)    │
+│  - om_render         │    └──────────────────────────┘
+└──────────────────────┘
+```
+
+### Data Flow
+
+```
+1. Hook loads config, validates payload, reads transcript (unchanged).
+2. Hook calls om_resolve_distill_template "$SLUG":
+     - Reads config.projects.overrides[slug].distill.template_path → if set+readable+nonempty: use it.
+     - Reads config.distill.template_path                         → if set+readable+nonempty: use it.
+     - Falls back to $PLUGIN_ROOT/templates/default-distillation.md.
+     - On "set but unreadable/empty", logs one stderr line and returns the bundled default.
+3. Hook cats the resolved file into $TMPL_RAW.
+4. Hook calls om_split_frontmatter "$TMPL_RAW" to produce $FM_RAW and $BODY_RAW.
+     - If the first non-blank line is `---` and a closing `---` exists later → split.
+     - Otherwise $FM_RAW="" and $BODY_RAW = $TMPL_RAW.
+5. Hook calls om_render on each region with the variable whitelist:
+     - jq -Rn --rawfile tmpl … --arg project_slug $SLUG … --arg transcript $CONVO
+              '$tmpl | gsub("\\{\\{project_slug\\}\\}"; $project_slug) | gsub…'
+     - Each whitelisted placeholder is replaced literally; non-whitelisted {{x}} pass through.
+6. Hook sends $PROMPT_OUT to `claude -p`.
+7. Hook writes the note file:
+     - If $FM_OUT is non-empty → emit $FM_OUT + "\n" + NOTE_BODY.
+     - Else                     → emit the legacy 7-field frontmatter + "\n" + NOTE_BODY.
+8. Hook appends the Index.md link line (unchanged).
+```
+
+---
+
+## API / Interface Changes
+
+### New helper functions in `scripts/_common.sh`
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `om_resolve_distill_template` | `om_resolve_distill_template "$slug" → echoes absolute path to template file` | Resolves per-project → global → bundled-default. Logs to stderr and returns the bundled default on "configured but unreadable." Never returns non-zero unless no usable template exists (which is impossible because the bundled default ships in the plugin). |
+| `om_split_frontmatter` | `om_split_frontmatter "$tmpl_raw" → prints FM block (may be empty), a 0-byte separator, then BODY block` | Splits a template file's content into (optional) YAML frontmatter and body. Uses awk (POSIX) — no bash 4+ features. Produces output via a separator so the caller can read both halves. |
+| `om_render` | `om_render "$text" → prints text with whitelisted `{{name}}` tokens replaced` | Invokes `jq -Rn --rawfile` with the six `--arg` values. Safe under any template content (no shell interpretation). Reads the expected vars from its environment (`SLUG`, `NOW_DATE`, `NOW_TIME`, `SESSION_ID`, `TRANSCRIPT`, `CONVO`) so the hook does not have to enumerate them at each call site. |
+
+### New public config keys
+
+```json
+{
+  "distill": {
+    "enabled": true,
+    "template_path": "/Users/me/.claude/obsidian-memory/templates/my-daily-note.md"
+  },
+  "projects": {
+    "mode": "all",
+    "excluded": [],
+    "allowed": [],
+    "overrides": {
+      "widgets": {
+        "distill": {
+          "template_path": "/Users/me/.claude/obsidian-memory/templates/work-note.md"
+        }
+      }
+    }
+  }
+}
+```
+
+- `distill.template_path` (string, optional) — absolute path, or relative path resolved against `$HOME`.
+- `projects.overrides.<slug>.distill.template_path` (string, optional) — same shape, per-project. The `overrides` sub-key is new in this spec; it sits *beside* `projects.{mode, excluded, allowed}` (the scope-policy stanza from #6) without touching them.
+
+### No CLI / HTTP / hook-payload changes
+
+The `SessionEnd` hook payload contract is unchanged. No new environment variables are introduced. No new required configuration — everything added is optional with backwards-compatible defaults.
+
+---
+
+## Database / Storage Changes
+
+Not applicable — obsidian-memory has no database. The only storage changes are:
+
+| Location | Change |
+|----------|--------|
+| `templates/default-distillation.md` | **New file** at the plugin root, containing the v0.1 prompt text with `{{project_slug}}` substituted in the one place `${SLUG}` currently appears. Shipped as part of the plugin. |
+| `scripts/_common.sh` | **Modified**: three new helper functions appended at the bottom (does not touch existing helpers). |
+| `scripts/vault-distill.sh` | **Modified**: removes the inline `PROMPT="..."` heredoc; replaces with helper calls. |
+| `~/.claude/obsidian-memory/config.json` | **Schema extension** (additive): new optional keys. Existing configs remain valid without any migration. |
+
+---
+
+## State Management
+
+Not applicable — there is no client-side or server-side state beyond the config file, which is read fresh on each hook invocation (snapshot already handled by `vault-session-start.sh` for scope policy; templates are NOT snapshotted because a mid-session template edit has no in-flight effect — `SessionEnd` is a single point-read, not a streaming state).
+
+---
+
+## UI Components
+
+Not applicable — the plugin has no UI. The only user-visible surfaces are:
+
+- The config JSON file (edited by hand or via `/obsidian-memory:setup`).
+- The doctor skill output (FR7 reports which template is in use).
+- The session notes themselves (obviously).
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Pros | Cons | Decision |
+|--------|-------------|------|------|----------|
+| **A: `envsubst`** | Read template, pipe through `envsubst '$project_slug $date …'` with only whitelisted vars allowed. | Familiar Unix tool, single-pipeline substitution. | `envsubst` with no arg list expands *every* `$VAR` it sees. With an arg list it still does not escape backticks or `$(…)` in POSIX shells that pre-expand. A template containing ``` `rm -rf ~` ``` becomes a hazard the moment anyone copy-pastes a template off the internet. Also adds a new dependency not listed in `steering/tech.md`. | Rejected — security. |
+| **B: bash `${var//pat/rep}` over a heredoc** | Read template into a bash variable, run six `${tmpl//\{\{name\}\}/$val}` expansions. | Zero new deps, in-stack. | macOS default bash 3.2 supports the syntax but mishandles multi-line heredocs with `\r`; quoting rules around `{{}}` in patterns are error-prone; single-char-at-a-time bash string ops are O(n²) on 10 KB templates. | Rejected — correctness and platform risk. |
+| **C: Python / Node Mustache helper** | Invoke a small Python or Node script to render the template with a strict context dict. | Cleanest substitution semantics; Mustache is industry-standard. | Adds a new runtime dependency not in `steering/tech.md`; breaks the "zero-network, one-subprocess" simplicity; increases install surface. | Rejected — scope. |
+| **D: `jq --rawfile | gsub`** | Read the template as a raw jq string, chain six `gsub` calls for the whitelist. | jq is already a pinned dep (≥1.6); `gsub` is literal regex replacement with no shell interpretation; single subprocess; output goes to stdout unchanged. `--rawfile` treats the file as an opaque string so no escaping is needed in either direction. | Slightly harder to read than Mustache; escape sequences in `gsub` patterns need `\\{\\{` to quote the literal braces. | **Selected**. |
+
+The template-format shape — Markdown with optional frontmatter — was also considered against alternatives:
+
+| Option | Description | Decision |
+|--------|-------------|----------|
+| Plain text body only (no frontmatter-as-output) | Template is just the prompt; the hook always emits its own frontmatter. | Rejected — breaks AC5; a user wanting a custom frontmatter would have to hand-edit files after the fact. |
+| Two separate files (prompt + frontmatter template) | `distill.prompt_path` + `distill.frontmatter_path`. | Rejected — two knobs for one concept; doubles the failure surface (AC3 would now need to specify behavior when one is readable and the other is not). |
+| Frontmatter is the default; body is optional | Invert the current proposal — template is primarily a frontmatter definition; the prompt defaults to the v0.1 prompt unless `{{prompt}}` is present. | Rejected — conflates two unrelated concerns. |
+| **Markdown file with optional `---` frontmatter** | What the design uses. Frontmatter is opt-in via `---` delimiters; the body is the prompt. | **Selected**. |
+
+---
+
+## Security Considerations
+
+- [x] **Authentication**: No change — the plugin has no auth layer.
+- [x] **Authorization**: Template paths come from `~/.claude/obsidian-memory/config.json`, which is operator-controlled. The plugin never accepts a template path from prompt content or hook payload, consistent with `steering/tech.md` → Security → "paths are read from config; the plugin never accepts paths from prompt content."
+- [x] **Input Validation**: The template path is checked for `-r` (readable regular file) and `-s` (non-empty). No content validation beyond that — the template is opaque text to the hook.
+- [x] **Data Sanitization**: The substitution whitelist is the only write of user-controlled data into the prompt. Each whitelisted value is either pre-sanitized by the plugin (slug) or comes from Claude Code's own `SessionEnd` payload (session_id, transcript_path) and is embedded as a jq string (`--arg`), never as argv text for an intermediate shell.
+- [x] **Sensitive Data**: The conversation transcript is already capped at ~200 KB by the existing hook. This spec does not loosen that cap. Templates are local files — no network transmission.
+- [x] **Code Injection**: The design's principal risk is "can a malicious template cause shell execution?" The answer is no by construction — the template file is read via `cat` (into a jq-managed string), never via `eval` or a heredoc that the shell re-scans. The only subprocess spawned after substitution is `claude -p`, which receives the rendered prompt as a single argv string.
+
+---
+
+## Performance Considerations
+
+- [x] **Caching**: None needed — `SessionEnd` fires once per session; the template is read once per invocation. No hot-path concern.
+- [x] **Pagination**: N/A.
+- [x] **Lazy Loading**: N/A.
+- [x] **Indexing**: N/A.
+- [x] **Latency budget**: The added work per invocation is one stat + one file read + one awk split + two jq invocations (`om_render` for frontmatter and for body). On a 10 KB template this runs in < 30 ms on typical hardware — well under the 50 ms NFR, and rounding error against `claude -p`'s multi-second dominant cost.
+
+---
+
+## Testing Strategy
+
+| Layer | Type | Coverage |
+|-------|------|----------|
+| Variable substitution | Unit (bats) | Every whitelist var replaced; non-whitelist `{{x}}` preserved; `$VAR`, backticks, `$(…)`, `${…}` preserved; multi-occurrence replacement; templates containing `{{` or `}}` stray braces. |
+| Frontmatter split | Unit (bats) | No frontmatter → empty FM, full body; frontmatter present → FM captured, body after `---`; malformed (opening `---` without closing) → treat as body, no FM. |
+| Template resolution | Unit (bats) | Per-project override wins; global wins when no override; default wins when neither is set; unreadable path falls back with stderr log; empty file falls back with stderr log. |
+| End-to-end default path | BDD (cucumber-shell) | AC2 — run hook with no `template_path` set, confirm prompt byte-identity against the golden fixture. |
+| End-to-end custom path | BDD | AC1 — run hook with a custom template, confirm the emitted file's structure matches the template. |
+| End-to-end fallback | BDD | AC3 — run hook with a bad `template_path`, confirm one stderr line + fallback + exit 0. |
+| End-to-end safety | BDD | AC4 — run hook with a template containing `$HOME`, backticks, `$(…)`, `{{user_email}}`; confirm none are expanded. |
+| End-to-end frontmatter | BDD | AC5 — run hook with a template that has a YAML frontmatter; confirm the output frontmatter matches (post-substitution). |
+
+All BDD tests use the existing scratch `$VAULT` / scratch `$HOME` / `claude -p` stub pattern established by #11's test suite. The `claude -p` stub produces deterministic output keyed on the prompt hash, so AC1/AC2/AC5 can assert file structure against golden fixtures.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Default-template drift — the bundled file diverges from the v0.1 hardcoded string, silently breaking AC2. | Medium (new file, new temptation to "improve" it) | High (silent change to every default-path user's notes) | (a) Remove the inline prompt string from `vault-distill.sh` in the same task that creates the template file — there is no second source of truth to diverge from. (b) Pin a golden-fixture byte-hash assertion in the AC2 BDD scenario so any future template-file edit surfaces as a failing test. |
+| Variable-substitution regex footgun — a future helper author uses an unescaped `.` or `+` in a gsub pattern and inadvertently matches outside the whitelist. | Low (jq gsub is regex) | Medium (could let a non-whitelisted token through) | Pin the gsub pattern shape in `_common.sh` to the literal `\\{\\{<name>\\}\\}` — one helper with a fixed pattern template, not ad-hoc regexes at each call site. Unit test covers a template containing `{{project_slugger}}` to confirm it does not get partially substituted. |
+| jq 1.5 on older Linux distributions — `--rawfile` landed in jq 1.5 but behavior on binary/invalid-UTF-8 content varied between 1.5 and 1.6. | Low (`steering/tech.md` pins ≥ 1.6 already) | Low | Keep the minimum-version check in `_common.sh`'s `command -v jq` guard as-is; document in the skill that templates must be UTF-8 (which is already the Markdown convention). |
+| Per-project override slug mismatch — user sets `projects.overrides.my_project.*` with an underscore, but `om_slug` produces `my-project`. | Medium | Low (override is silently ignored) | The doctor skill (FR7) reports the active template, which surfaces the mismatch. Additionally, `om_resolve_distill_template` logs at `debug` verbosity when a per-project override key is present but the computed slug does not match any override. |
+| Frontmatter detection false positive — a template whose body happens to start with `---` (e.g., a horizontal rule followed by Markdown) is mis-parsed as having frontmatter. | Low | Low (frontmatter block looks weird; substitution still works) | Detection requires the first non-blank line to be exactly `---` AND a later line to be exactly `---`. A horizontal rule after content would not match (no leading `---`). Documented in the skill and covered by a dedicated unit test. |
+
+---
+
+## Open Questions
+
+- [ ] Should `om_render` also substitute an `{{hostname}}` token for users who want per-machine notes? Deferred — the whitelist is explicitly locked per FR3, and the issue's use cases don't require it.
+- [ ] Does the per-project override lookup need to run once per hook invocation, or can it be cached? Deferred — the hook runs once per session; caching inside a single run adds complexity for zero measurable benefit.
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #7 | 2026-04-22 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to TASKS phase:
+
+- [x] Architecture follows existing project patterns (helpers in `_common.sh`, one modified hook, no new dependencies)
+- [x] All API/interface changes documented (three new helpers, two new optional config keys)
+- [x] Storage changes planned (one new top-level `templates/` dir, one new file, `_common.sh` + `vault-distill.sh` modifications)
+- [x] State management approach is clear (none — stateless per invocation)
+- [x] UI components addressed (N/A, no UI)
+- [x] Security considerations addressed (jq literal substitution, no shell interpretation, paths from operator-controlled config only)
+- [x] Performance impact analyzed (< 50 ms added; negligible vs `claude -p` dominant cost)
+- [x] Testing strategy defined (unit + BDD across every AC)
+- [x] Alternatives were considered and documented (`envsubst`, bash param expansion, Mustache helper, jq gsub — and four template-format shapes)
+- [x] Risks identified with mitigations (default drift, regex footgun, jq version, slug mismatch, false-positive frontmatter)

--- a/specs/feature-make-distillation-template-configurable/feature.gherkin
+++ b/specs/feature-make-distillation-template-configurable/feature.gherkin
@@ -1,0 +1,101 @@
+# File: specs/feature-make-distillation-template-configurable/feature.gherkin
+#
+# Generated from: specs/feature-make-distillation-template-configurable/requirements.md
+# Issue: #7
+#
+# Runner note: tests/run-bdd.sh supports only single-line steps with quoted
+# literals; DocStrings are silently skipped. Template bodies are therefore
+# expressed as \n-escaped strings that the step helpers decode via printf %b,
+# matching the `with content` pattern already used by other features.
+
+Feature: Configurable distillation template
+  As a Claude Code + Obsidian power user with a strong opinion on note formatting
+  I want to customize the Markdown template used by vault-distill.sh
+  So that my vault notes follow my existing conventions instead of the plugin's opinionated default
+
+  Background:
+    Given a scratch HOME at "$BATS_TEST_TMPDIR/home"
+    And a scratch Obsidian vault at "$BATS_TEST_TMPDIR/vault"
+    And obsidian-memory is installed and setup against "$VAULT"
+    And a stub "claude" CLI is on PATH returning a fixed distillation by default
+    And a prompt-capturing claude stub is installed at "$BATS_TEST_TMPDIR/bin"
+    And a transcript at "$HOME/.claude/projects/widgets/sess.jsonl" of size 5000 bytes
+
+  # --- AC1: Custom template overrides the default ---
+
+  Scenario: A user-provided template path overrides the default
+    Given a readable template at "$HOME/.claude/obsidian-memory/templates/mine.md" with content "# {{project_slug}} — {{date}}\n\n## What Happened\n\n{{transcript}}\n\n## Next\n\n(filled in by claude)\n"
+    And the config sets "distill.template_path" to "$HOME/.claude/obsidian-memory/templates/mine.md"
+    When SessionEnd fires with cwd "/tmp/widgets", session_id "abc123"
+    Then the captured prompt starts with "# widgets — " followed by today's UTC date
+    And the captured prompt contains "## What Happened"
+    And the captured prompt does NOT contain the bare token "{{project_slug}}"
+    And the captured prompt does NOT contain the bare token "{{date}}"
+    And the captured prompt does NOT contain the bare token "{{transcript}}"
+    And a session note file exists under "$VAULT/claude-memory/sessions/widgets/"
+    And the hook exit code is 0
+
+  # --- AC2: Default behavior unchanged when no template_path is configured ---
+
+  Scenario: Default behavior when no template_path is configured
+    When SessionEnd fires with cwd "/tmp/widgets", session_id "abc123"
+    Then the captured prompt prefix matches the golden fixture "tests/fixtures/distill/v0.1-prompt.txt"
+    And the latest session note under "$VAULT/claude-memory/sessions/widgets/" starts with a YAML frontmatter block with keys in order "date,time,session_id,project,cwd,end_reason,source"
+    And the Index.md line under "$VAULT/claude-memory/Index.md" matches the v0.1 pattern "^- \[\[sessions/widgets/[0-9-]+\.md\]\] — widgets \([0-9-]+ [0-9:]+ UTC\)$"
+    And the hook exit code is 0
+
+  Scenario: Explicitly pointing at the bundled default matches the unconfigured behavior
+    Given the config sets "distill.template_path" to the bundled default template
+    When SessionEnd fires with cwd "/tmp/widgets", session_id "abc123"
+    Then the captured prompt prefix matches the golden fixture "tests/fixtures/distill/v0.1-prompt.txt"
+    And the hook exit code is 0
+
+  # --- AC3: Missing / unreadable template falls back to default ---
+
+  Scenario: Unreadable template_path falls back to the bundled default
+    Given the config sets "distill.template_path" to "$HOME/does/not/exist.md"
+    When SessionEnd fires with cwd "/tmp/widgets", session_id "abc123"
+    Then the hook stderr contains exactly one line matching "^\[vault-distill\.sh\] distill\.template_path=.* unreadable; falling back to default template$"
+    And the captured prompt prefix matches the golden fixture "tests/fixtures/distill/v0.1-prompt.txt"
+    And a session note file exists under "$VAULT/claude-memory/sessions/widgets/"
+    And the hook exit code is 0
+
+  Scenario: Empty-file template_path falls back to the bundled default
+    Given an empty file at "$HOME/.claude/obsidian-memory/templates/empty.md"
+    And the config sets "distill.template_path" to "$HOME/.claude/obsidian-memory/templates/empty.md"
+    When SessionEnd fires with cwd "/tmp/widgets", session_id "abc123"
+    Then the hook stderr contains exactly one line matching "^\[vault-distill\.sh\] distill\.template_path=.* unreadable; falling back to default template$"
+    And the captured prompt prefix matches the golden fixture "tests/fixtures/distill/v0.1-prompt.txt"
+    And the hook exit code is 0
+
+  # --- AC4: Substitution is safe — only whitelisted {{...}} tokens are replaced ---
+
+  Scenario: Shell-looking syntax in the template is NOT expanded
+    Given a readable template at "$HOME/.claude/obsidian-memory/templates/safe.md" with content "# {{project_slug}} on {{date}}\n\nHOME is $HOME — this should be literal\nBackticks: `whoami` — literal\nSubstitution: $(date) — literal\nBraced: ${PATH} — literal\nNon-whitelist: {{user_email}} — literal placeholder\nWhitelist: transcript_path is {{transcript_path}}\n\n{{transcript}}\n"
+    And the config sets "distill.template_path" to "$HOME/.claude/obsidian-memory/templates/safe.md"
+    When SessionEnd fires with cwd "/tmp/widgets", session_id "abc123"
+    Then the captured prompt contains the literal substring "HOME is $HOME — this should be literal"
+    And the captured prompt contains the literal substring "Backticks: `whoami` — literal"
+    And the captured prompt contains the literal substring "Substitution: $(date) — literal"
+    And the captured prompt contains the literal substring "Braced: ${PATH} — literal"
+    And the captured prompt contains the literal substring "Non-whitelist: {{user_email}} — literal placeholder"
+    And the captured prompt contains "# widgets on " followed by today's UTC date
+    And the captured prompt does NOT contain the bare token "{{project_slug}}"
+    And the captured prompt does NOT contain the bare token "{{date}}"
+    And the captured prompt does NOT contain the bare token "{{transcript_path}}"
+    And the hook exit code is 0
+
+  # --- AC5: Custom frontmatter is preserved in the output ---
+
+  Scenario: Template-supplied YAML frontmatter replaces the default seven-field block
+    Given a readable template at "$HOME/.claude/obsidian-memory/templates/fm.md" with content "---\ntitle: \"{{project_slug}} — {{date}}\"\ntags: [daily-note]\nsource: claude-code\n---\n\n# Summary\n\n{{transcript}}\n"
+    And the config sets "distill.template_path" to "$HOME/.claude/obsidian-memory/templates/fm.md"
+    When SessionEnd fires with cwd "/tmp/widgets", session_id "abc123"
+    Then the latest session note under "$VAULT/claude-memory/sessions/widgets/" starts with exactly 5 frontmatter lines beginning with "---" and ending with "---"
+    And the latest session note first frontmatter line is "---"
+    And the latest session note second frontmatter line starts with "title: \"widgets — "
+    And the latest session note third frontmatter line is "tags: [daily-note]"
+    And the latest session note fourth frontmatter line is "source: claude-code"
+    And the latest session note does NOT contain a second frontmatter block with "end_reason:"
+    And the captured prompt does NOT contain "---\n" at the start
+    And the hook exit code is 0

--- a/specs/feature-make-distillation-template-configurable/requirements.md
+++ b/specs/feature-make-distillation-template-configurable/requirements.md
@@ -1,0 +1,240 @@
+# Requirements: Configurable distillation template
+
+**Issues**: #7
+**Date**: 2026-04-22
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## User Story
+
+**As a** Claude Code + Obsidian power user with a strong opinion on how my distilled session notes should read
+**I want** to customize the Markdown template used by `vault-distill.sh`
+**So that** my vault notes follow my existing conventions (frontmatter, tags, section order) instead of the plugin's opinionated default.
+
+---
+
+## Background
+
+`scripts/vault-distill.sh` today generates notes using a single hardcoded prompt that instructs `claude -p` to emit a **Summary / Decisions / Patterns & Gotchas / Open Threads / Tags** layout. That is a reasonable default, but it is not universal — some users want frontmatter (dates, source links, status), different section names, or an entirely different layout matching their Daily Note / Zettelkasten / PARA workflow. Forcing those users to fork the script is incompatible with `steering/product.md` → Target Users → AI-tooling tinkerer ("retrieval and distillation must be replaceable script-level components").
+
+`steering/product.md` → Feature Prioritization → Could Have names this capability explicitly: *"Configurable distillation template."* This spec promotes it into the v1 MVP scope.
+
+The current state relevant to this work:
+
+- `scripts/vault-distill.sh` embeds the distillation prompt inline as a single `PROMPT="..."` heredoc-style string with one interpolation (`${SLUG}` inside the `#project/<slug>` Tags line).
+- The hook writes a hardcoded YAML frontmatter block (`date`, `time`, `session_id`, `project`, `cwd`, `end_reason`, `source: claude-code`) regardless of what `claude -p` produces.
+- `~/.claude/obsidian-memory/config.json` is a flat JSON object with `vaultPath`, `rag.*`, `distill.*`, and (since #6) a `projects` stanza with `mode` / `excluded` / `allowed`. No template-related keys exist.
+- `steering/tech.md` → Technology Stack pins `jq` ≥ 1.6 as a required dependency. `_common.sh` already uses `jq` for all config reads, so jq-based template variable substitution is in-stack and does not add a new dependency.
+- The per-project override framework from #6 (merged in PR #18) ships `projects.{mode, excluded, allowed}` but does not ship a `projects.overrides` sub-key. This spec adds one, scoped to the template-path use case, without changing the shape of the existing scope policy fields.
+
+**Missing-template behavior decision (AC3 / FR5).** The issue leaves AC3 open — the spec must pick **fallback to default** vs. **silent exit 0**. This spec picks **fallback to the bundled default template**, with a single stderr log line. Rationale:
+
+1. `steering/product.md` → Product Principles → "Never blocks the user" requires the hook to exit 0, which both options satisfy.
+2. Silent exit 0 would *also* throw away the session note — every session would be silently lost whenever the user's template path went stale (typo, file moved, permissions changed). That is a strictly worse outcome than receiving a correctly-formatted note in the default layout.
+3. The bundled default template (FR4) is shipped inside the plugin and is always readable, so fallback cannot itself fail under any reasonable operator state.
+4. Logging to stderr matches the existing hook pattern (`log_err` in the `_common.sh` preamble) — the operator can see the problem in the hook log without the user's session ever being affected.
+
+**Template file format decision.** A template is a single Markdown file with two regions:
+
+1. **Optional YAML frontmatter** at the very top, delimited by `---` lines. Variables are substituted inside this block. If the template has frontmatter, the hook emits **that** frontmatter (after substitution) and does **not** emit its own default seven-field block.
+2. **Prompt body** — everything after the frontmatter, or the whole file if no frontmatter is present. Variables are substituted, then the body is sent to `claude -p` as the prompt. If the body contains the literal token `{{transcript}}`, the extracted conversation replaces that token; otherwise the conversation is appended after a blank line + `TRANSCRIPT:` label (preserving v0.1 behavior byte-for-byte when no marker is used).
+
+This split lets AC5 be a clean "the frontmatter appears unchanged" check and keeps the prompt body flexible without forcing users to learn a second template format.
+
+**Variable whitelist.** `project_slug`, `date`, `time`, `session_id`, `transcript_path`, `transcript`. The issue's FR3 lists the first five; `transcript` is added to support body-position control (AC4 stipulates the `{{...}}` syntax and FR3 stipulates the first five names — `transcript` is an additive token needed for the prompt to be functional without magic trailing-append behavior, documented here). All six are substituted via `jq --arg ... | gsub("\\{\\{name\\}\\}"; $name)` — literal string replacement with no shell, no `eval`, no `envsubst`. Any `{{other_name}}` token not in the whitelist is left as literal text in the output. Any `$VAR`, `` `cmd` ``, or `$(cmd)` syntax in the template is likewise never expanded.
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: A user-provided template path overrides the default
+
+**Given** `distill.template_path` in `~/.claude/obsidian-memory/config.json` points at a readable Markdown file with a custom layout (for example, sections `## What Happened`, `## Next`, `## Links`)
+**And** setup has been run against `$VAULT`
+**And** `distill.enabled=true`
+**When** a `SessionEnd` event fires with a transcript ≥ 2 KB
+**Then** the prompt sent to `claude -p` is the contents of the configured template (with whitelisted variables substituted)
+**And** the resulting session note under `<VAULT>/claude-memory/sessions/<slug>/YYYY-MM-DD-HHMMSS.md` follows the structure described by the template
+**And** the hook exits 0.
+
+**Example**:
+- Given: `/path/to/my-template.md` contains `# {{project_slug}} — {{date}}\n\n## What Happened\n\n{{transcript}}`
+- When: session ends with `transcript_path=/tmp/t.jsonl`, `cwd=/Users/me/code/widgets`
+- Then: the prompt sent to claude is `# widgets — 2026-04-22\n\n## What Happened\n\n<conversation text>`
+
+### AC2: Default behavior unchanged when no template is configured
+
+**Given** `distill.template_path` is absent from config (or the whole `distill` stanza contains only `enabled`)
+**And** setup has been run against `$VAULT`
+**And** `distill.enabled=true`
+**When** a `SessionEnd` event fires with a transcript ≥ 2 KB
+**Then** the prompt sent to `claude -p` is byte-for-byte identical to the prompt `vault-distill.sh` emitted at v0.1 (modulo `${SLUG}` → `{{project_slug}}` substitution of the one slug reference)
+**And** the emitted file frontmatter is the v0.1 seven-field block (`date`, `time`, `session_id`, `project`, `cwd`, `end_reason`, `source`)
+**And** the `<VAULT>/claude-memory/Index.md` link format is unchanged.
+
+**Example**: running with no `distill.template_path` in config must produce, when compared against a v0.1 run of the same transcript with a fixed `claude -p` stub, an identical note except for wall-clock-dependent timestamp fields.
+
+### AC3: Missing or unreadable template falls back to the default
+
+**Given** `distill.template_path` points at a file that does not exist, is not readable (permissions), or is empty
+**And** `distill.enabled=true`
+**When** a `SessionEnd` event fires with a transcript ≥ 2 KB
+**Then** the hook writes a single stderr line of the form `[vault-distill.sh] distill.template_path=<path> unreadable; falling back to default template`
+**And** the hook falls back to the bundled default template at `<plugin-root>/templates/default-distillation.md`
+**And** the session note is written as if no template had been configured
+**And** the hook exits 0.
+
+### AC4: Template variables are substituted safely
+
+**Given** a template containing the tokens `{{project_slug}}`, `{{date}}`, `{{time}}`, `{{session_id}}`, `{{transcript_path}}`, and `{{transcript}}`
+**And** a template containing shell-looking syntax like `$HOME`, `` `whoami` ``, `$(date)`, `${PATH}`, and a non-whitelisted token `{{user_email}}`
+**When** the hook substitutes variables before sending the prompt to `claude -p`
+**Then** each of the six whitelisted tokens is replaced with its corresponding sanitized value (exact replacement, not pattern-expanded)
+**And** `$HOME`, backticks, `$()`, `${…}`, and `{{user_email}}` appear in the substituted prompt verbatim (never expanded or resolved)
+**And** no subprocess other than the single `claude -p` call is spawned as a side effect of substitution.
+
+**Example**:
+- Template body: `# {{project_slug}} on {{date}} — see {{transcript_path}}\n$HOME should be literal\n{{user_email}} stays a placeholder`
+- Substituted (for slug=`widgets`, date=`2026-04-22`, transcript_path=`/tmp/t.jsonl`): `# widgets on 2026-04-22 — see /tmp/t.jsonl\n$HOME should be literal\n{{user_email}} stays a placeholder`
+
+### AC5: Custom frontmatter is preserved in the output
+
+**Given** a template whose first characters are a YAML frontmatter block, e.g.:
+```
+---
+title: "{{project_slug}} — {{date}}"
+tags: [daily-note]
+source: claude-code
+---
+
+# Summary
+
+{{transcript}}
+```
+**When** the distilled note is written
+**Then** the output file begins with exactly that frontmatter block (with `{{project_slug}}` and `{{date}}` substituted) followed by a single blank line and then the body produced by `claude -p`
+**And** the hook does **not** emit its own default seven-field frontmatter in addition to the template's
+**And** no additional frontmatter key is inserted or removed.
+
+---
+
+## Functional Requirements
+
+| ID | Requirement | Priority | Notes |
+|----|-------------|----------|-------|
+| FR1 | Add `distill.template_path` to the config schema — optional string, interpreted as an absolute path. | Must | Written by the user (or by a future `/obsidian-memory:setup` flag); never inferred from prompt content. |
+| FR2 | When `distill.template_path` is set and the file is readable and non-empty, `vault-distill.sh` uses that file as the distillation prompt template (after variable substitution) instead of the hardcoded inline prompt. | Must | Resolution order: per-project override (FR8) > global `distill.template_path` > bundled default. |
+| FR3 | Substitute only the whitelist `{project_slug, date, time, session_id, transcript_path, transcript}` using `jq --arg … \| gsub("\\{\\{name\\}\\}"; $name)`. No `eval`, no `envsubst`, no shell expansion of `$VAR` / backticks / `$(…)` / `${…}`. Non-whitelist `{{…}}` tokens pass through verbatim. | Must | All six values are pre-sanitized: `project_slug` is `[a-z0-9-]` per `om_slug`; `date`/`time` are generated from `date -u`; `session_id` and `transcript_path` come from the hook payload; `transcript` is the already-truncated JSONL extraction. |
+| FR4 | Ship the current default template as a visible file at `templates/default-distillation.md` in the plugin root. Document that copying it to `~/.claude/obsidian-memory/templates/my-template.md` and pointing `distill.template_path` at the copy is the supported customization flow. | Must | The default template is the source of truth for AC2 — the hardcoded prompt string in `vault-distill.sh` is removed; the default template file becomes the sole definition of v0.1 layout. |
+| FR5 | Missing-template behavior on an unreadable / empty / nonexistent `distill.template_path`: log one stderr line and fall back to the bundled default. Never exit non-zero, never skip the distillation. | Must | See Background → Missing-template behavior decision for rationale. |
+| FR6 | The existing distillation BDD scenarios (#11, referenced from `specs/feature-session-distillation-hook/feature.gherkin`) must continue to pass. The default-template path (no `distill.template_path` configured) and the explicitly-configured-default-template path (`distill.template_path=<plugin-root>/templates/default-distillation.md`) must both satisfy AC2 with the same observable output. | Must | Adds one new scenario per path to this feature's Gherkin; does not rewrite the #11 Gherkin. |
+| FR7 | `/obsidian-memory:doctor` (feature-doctor-health-check-skill) reports which template is in use: either `default (bundled)`, `global: <path>`, `project-override(<slug>): <path>`, or `configured but unreadable — falling back to default`. | Should | Lives in the doctor skill's output; this spec only requires the field is present and the string format is one of the four listed. |
+| FR8 | Per-project template override via `projects.overrides.<slug>.distill.template_path` — when set and readable, takes precedence over `distill.template_path` for that project slug. | Could | Depends on #6 per-project overrides framework (already landed via PR #18). FR8 uses the `projects.overrides` sub-key to avoid shape collision with `projects.{mode, excluded, allowed}` — the `overrides` sub-key is new. |
+
+---
+
+## Non-Functional Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| **Performance** | Template load + substitution must add < 50 ms to the distill hook's wall time. Far below the hook's `claude -p` dominant cost; primarily a guardrail against pathological templates. The variable-substitution pass is a single `jq` invocation. |
+| **Security** | `distill.template_path` is read as a local file path only. No URL schemes. No `..` traversal guard is required because the path comes from config (operator-controlled, never from prompt content), consistent with `steering/tech.md` → Security → "paths are read from config; the plugin never accepts paths from prompt content." Variable substitution uses `jq gsub` literal replacement — no interpretation of template content as shell or code. |
+| **Accessibility** | N/A — no UI surface. |
+| **Reliability** | Every hook exit path remains `exit 0`. A malformed template (syntactically valid UTF-8 but nonsensical content) produces whatever `claude -p` yields for it; the hook does not validate template content. Bundled default is immutable during install and guaranteed readable — fallback cannot fail. |
+| **Platforms** | macOS default bash 3.2 + Linux bash 4+, per `steering/tech.md`. The substitution implementation must not rely on bash 4+ features (no `${var//pat/rep}` over heredocs; use `jq`). |
+
+---
+
+## Data Requirements
+
+### Input Data
+
+| Field | Type | Validation | Required |
+|-------|------|------------|----------|
+| `distill.template_path` | string | Must be a readable regular file when set. Absolute path recommended; relative paths are resolved against `$HOME`. | No |
+| `projects.overrides.<slug>.distill.template_path` | string | Same validation as above. `<slug>` must match `[a-z0-9-]{1,60}` (the `om_slug` output charset). | No |
+| Template file | UTF-8 text | File must be non-empty. Optional YAML frontmatter must be delimited by exactly two `---` lines (first non-whitespace line is `---`, and the matching closing `---` appears before any other `---` line). | Yes when `template_path` is set |
+
+### Output Data
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Session note file | Markdown | `<VAULT>/claude-memory/sessions/<slug>/YYYY-MM-DD-HHMMSS.md`. Frontmatter is either (a) the template's frontmatter after variable substitution (AC5), or (b) the hook's default seven-field block (AC2). Body is `claude -p` output. |
+| Stderr log line | text | Emitted only when the configured template is unreadable; format pinned in AC3. |
+| Index line | Markdown | Unchanged from v0.1: `- [[sessions/<slug>/<ts>.md]] — <slug> (<date> <time> UTC)`. |
+
+---
+
+## Dependencies
+
+### Internal Dependencies
+
+- [x] `scripts/_common.sh` — slug helper, config loader, per-project policy readers.
+- [x] `scripts/vault-distill.sh` — the hook this spec modifies.
+- [x] `projects.{mode,excluded,allowed}` config stanza from #6 — unchanged; this spec adds a sibling `projects.overrides` sub-key.
+
+### External Dependencies
+
+- [x] `jq` ≥ 1.6 — already required (`steering/tech.md`).
+- [x] `claude` CLI — already required.
+
+### Blocked By
+
+- [ ] Issue #1 — the BDD harness (bats-core + cucumber-shell) is required to execute AC2 (byte-for-byte prompt-equivalence) and AC4 (substitution safety) in CI. Implementation of this spec can proceed without #1; verification requires it.
+
+---
+
+## Out of Scope
+
+- A DSL for multi-template composition (e.g., one template for coding sessions, another for planning sessions). Single template per config scope is sufficient for v1.
+- Live preview / editing UI for templates.
+- Bundled alternate templates (Daily Note, PARA, Zettelkasten, etc.) — one default plus the "copy and edit" pattern is sufficient.
+- Template includes / partials (`{{> header}}`) — the template is a single file.
+- Hot-reload of the template within a single session — `SessionEnd` reads the path fresh on each invocation, which is enough.
+- Validating template content for well-formed Markdown or YAML frontmatter — garbage in, garbage out; `claude -p` handles most malformations gracefully and the spec does not attempt to.
+- Changing the output file path or the Index.md line format — both remain pinned to the #11 baseline.
+
+---
+
+## Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Default-path parity | 100% of default-path runs produce a prompt byte-identical to the v0.1 prompt (modulo `{{project_slug}}` expansion) | AC2 BDD scenario compares the prompt string against a golden fixture checked in at `tests/fixtures/distill/v0.1-prompt.txt`. |
+| Fallback silence | 0 user-visible errors when `distill.template_path` points at a bad file across 5 repeated SessionEnd events | AC3 BDD scenario; stderr log lines are captured but not surfaced to the user. |
+| Substitution safety | 0 instances of shell-syntax expansion (`$VAR`, backticks, `$(…)`) when those tokens appear literally in a template | AC4 BDD scenario with a template that intentionally contains each form. |
+
+---
+
+## Open Questions
+
+- [ ] Should `/obsidian-memory:setup` grow a `--template-path=<path>` flag that writes `distill.template_path` into config? The issue doesn't demand it; FR7 (doctor reports it) plus hand-editing config is enough for v1. Deferred unless setup spec amendment wants it.
+- [ ] Should a global `templates/` directory under `~/.claude/obsidian-memory/` be implicitly searched when `distill.template_path` is a bare filename? Decided: no — paths in config are absolute; `$HOME` is the only relative base. Keeps the resolution rule one line.
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #7 | 2026-04-22 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to PLAN phase:
+
+- [x] User story follows "As a / I want / So that" format
+- [x] All acceptance criteria use Given/When/Then format
+- [x] No implementation details bleed into the ACs (design.md picks the jq-gsub mechanism; ACs pin only the observable behavior)
+- [x] All criteria are testable and unambiguous
+- [x] Success metrics are measurable
+- [x] Edge cases and error states are specified (AC3, AC4, AC5)
+- [x] Dependencies are identified (#1 for BDD verification; #6 for the overrides key shape)
+- [x] Out of scope is defined
+- [x] Open questions are documented (template-path flag for setup; implicit `~/.claude/obsidian-memory/templates/` search — deferred)

--- a/specs/feature-make-distillation-template-configurable/tasks.md
+++ b/specs/feature-make-distillation-template-configurable/tasks.md
@@ -1,0 +1,278 @@
+# Tasks: Configurable distillation template
+
+**Issues**: #7
+**Date**: 2026-04-22
+**Status**: Planning
+**Author**: Rich Nunley
+
+---
+
+## Summary
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Setup | 2 | [ ] |
+| Backend | 4 | [ ] |
+| Integration | 2 | [ ] |
+| Testing | 4 | [ ] |
+| **Total** | 12 | |
+
+There is no Frontend phase — obsidian-memory has no UI layer (per `steering/structure.md`). Skill-output changes (FR7 in the doctor skill) are grouped under Integration.
+
+---
+
+## Task Format
+
+Each task follows:
+
+```
+### T[NNN]: [Task Title]
+
+**File(s)**: `path/to/file`
+**Type**: Create | Modify | Delete
+**Depends**: T[NNN] (or None)
+**Acceptance**:
+- [ ] [Verifiable criterion]
+
+**Notes**: [Optional implementation hints]
+```
+
+---
+
+## Phase 1: Setup
+
+### T001: Create the `templates/` directory with the bundled default template
+
+**File(s)**: `templates/default-distillation.md`
+**Type**: Create
+**Depends**: None
+**Acceptance**:
+- [ ] The file exists at `<repo-root>/templates/default-distillation.md`.
+- [ ] The file's contents are a byte-for-byte transcription of the current `PROMPT="..."` string in `scripts/vault-distill.sh` (lines 92–117), with the one `${SLUG}` reference replaced by the literal token `{{project_slug}}`.
+- [ ] The file ends with a single trailing newline.
+- [ ] The file contains no YAML frontmatter block (the default emits the hook's seven-field frontmatter, so the template must not have its own).
+
+**Notes**: This file is the **sole source of truth** for the v0.1 layout after T002 strips the inline prompt from the hook. The golden-fixture hash assertion from T012 runs against this file; any future edit will surface as a failing AC2 scenario. Keep the "TRANSCRIPT:" marker at the tail — the hook currently appends the conversation after that marker, and AC2 requires byte-identity with the v0.1 prompt.
+
+### T002: Carve out space in `_common.sh` for the new helpers
+
+**File(s)**: `scripts/_common.sh`
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [ ] A new section comment `# --- Template resolution, frontmatter split, variable substitution (issue #7) ---` is appended at the bottom of `_common.sh` immediately above three stub functions `om_resolve_distill_template`, `om_split_frontmatter`, `om_render`.
+- [ ] Each stub echoes a deterministic sentinel (`# NOT_IMPLEMENTED_T003/T004/T005`) so downstream tasks can be implemented and unit-tested independently.
+- [ ] `bats tests/unit/common.bats` still passes against the existing `_common.sh` API surface — no existing helper is renamed or relocated.
+
+**Notes**: This task is purely structural. It exists so T003/T004/T005 can be independently reviewable diffs instead of one 150-line change.
+
+---
+
+## Phase 2: Backend Implementation
+
+### T003: Implement `om_render` — whitelisted variable substitution
+
+**File(s)**: `scripts/_common.sh`
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] `om_render` reads the candidate text from its single positional argument (`$1`) and reads the six substitution values from its environment: `SLUG`, `NOW_DATE`, `NOW_TIME`, `SESSION_ID`, `TRANSCRIPT`, `CONVO` (the last substitutes `{{transcript}}`).
+- [ ] Implementation uses a single `jq -Rn --arg text "$1" --arg project_slug "$SLUG" --arg date "$NOW_DATE" --arg time "$NOW_TIME" --arg session_id "$SESSION_ID" --arg transcript_path "$TRANSCRIPT" --arg transcript "$CONVO"` invocation with chained `gsub("\\{\\{project_slug\\}\\}"; $project_slug) | gsub(…)` calls for each of the six tokens.
+- [ ] No subprocess other than the single `jq` is spawned.
+- [ ] On jq failure (rare — hard filesystem error), the function echoes the input text unchanged and returns 0. The hook never exits non-zero because of a substitution problem.
+- [ ] Shellcheck clean.
+
+**Notes**: Use `--arg text "$1"` (not `--rawfile`) because the input is already a bash string, not a file. `--rawfile` is reserved for the template-file read in T006. Make the gsub pattern a shared constant or inlined uniformly so T011's regex-footgun test can pin the exact literal pattern.
+
+### T004: Implement `om_split_frontmatter` — YAML frontmatter detection and split
+
+**File(s)**: `scripts/_common.sh`
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] `om_split_frontmatter` takes a single positional arg (the full template contents) and prints two regions to stdout separated by a single 0x1E (record separator) byte: `<frontmatter><0x1E><body>`.
+- [ ] Detection: if the first non-empty line is exactly `---` AND a subsequent line is exactly `---`, split. Otherwise the frontmatter is empty and the body is the entire input.
+- [ ] The split is inclusive on both `---` lines into the frontmatter region; the body region begins on the line immediately after the closing `---`.
+- [ ] Implementation uses `awk` (POSIX) — no bash 4+ features, no `mapfile`, no `readarray`.
+- [ ] A malformed template (opening `---` with no closing `---`) is treated as having no frontmatter; the entire text falls into the body region.
+- [ ] Shellcheck clean.
+
+**Notes**: The 0x1E separator is a single byte unlikely to appear in Markdown; `printf '\x1E'` is the emit. Callers split on it via `IFS=$'\x1E' read -r fm body < <(om_split_frontmatter "$tmpl")`.
+
+### T005: Implement `om_resolve_distill_template` — resolution + fallback + stderr logging
+
+**File(s)**: `scripts/_common.sh`
+**Type**: Modify
+**Depends**: T002
+**Acceptance**:
+- [ ] `om_resolve_distill_template` takes a single positional arg `$slug` and echoes one absolute path.
+- [ ] Resolution order: (a) `projects.overrides.<slug>.distill.template_path`, (b) `distill.template_path`, (c) `<plugin-root>/templates/default-distillation.md` where `<plugin-root>` is derived from `$(dirname "$0")/..`.
+- [ ] A path is used when `[ -r "$path" ] && [ -s "$path" ]` (readable regular file, non-empty).
+- [ ] When a configured path (a) or (b) exists as a string but fails the readable/non-empty check, exactly one stderr line is emitted: `[vault-distill.sh] distill.template_path=<path> unreadable; falling back to default template`. The scope (a or b) is identifiable by including the slug in the message when (a) failed: `[vault-distill.sh] projects.overrides.<slug>.distill.template_path=<path> unreadable; falling back to default template`.
+- [ ] Only one stderr line per invocation — if both (a) and (b) are configured-but-broken, log once for whichever is consulted first (the override), and silently fall through.
+- [ ] Returns 0 always. The bundled default's existence is an invariant of the plugin install, not a runtime check.
+- [ ] Relative paths in config are resolved against `$HOME` (`case "$path" in /*) ;; *) path="$HOME/$path" ;; esac`).
+- [ ] Shellcheck clean.
+
+**Notes**: Read the two config paths in a single `jq -r` for efficiency: `.projects.overrides."'"$slug"'".distill.template_path // "", .distill.template_path // ""` — guard the slug with `@sh` or by quoting appropriately (slug charset is `[a-z0-9-]`, so direct interpolation is safe).
+
+### T006: Integrate the three helpers into `vault-distill.sh`
+
+**File(s)**: `scripts/vault-distill.sh`
+**Type**: Modify
+**Depends**: T003, T004, T005
+**Acceptance**:
+- [ ] The inline `PROMPT="You are distilling…${CONVO}"` block (current lines 92–117) is removed.
+- [ ] After `CONVO` is built, the hook calls:
+  1. `TEMPLATE_PATH="$(om_resolve_distill_template "$SLUG")"`
+  2. `TMPL_RAW="$(cat "$TEMPLATE_PATH" 2>/dev/null)"` — if empty, re-resolve against the bundled default and log once.
+  3. `IFS=$'\x1E' read -rd '' FM_RAW BODY_RAW < <(om_split_frontmatter "$TMPL_RAW")`
+  4. `FM_OUT="$(om_render "$FM_RAW")"`
+  5. `PROMPT="$(om_render "$BODY_RAW")"`
+- [ ] The `NOTE_BODY="$(CLAUDECODE="" claude -p "$PROMPT" 2>/dev/null)"` call is unchanged.
+- [ ] Output emission logic:
+  - When `FM_OUT` is non-empty, the output file contents are `${FM_OUT}\n\n${NOTE_BODY}` (or the legacy empty-body fallback if `NOTE_BODY` is empty).
+  - When `FM_OUT` is empty, the hook emits the existing seven-field frontmatter block unchanged, followed by `${NOTE_BODY}`.
+- [ ] The Index.md update logic is untouched.
+- [ ] The hook still exits 0 on every terminating path.
+- [ ] Shellcheck clean.
+
+**Notes**: If `TMPL_RAW` is empty after a cat from the resolved path, re-run `om_resolve_distill_template` with an env flag that forces the bundled default and log once — this handles a narrow race where the user deletes the configured template between `om_resolve_distill_template`'s `[ -s ]` check and the `cat`. The simpler path: do not implement that race guard; rely on `om_resolve_distill_template`'s `[ -s ]` check being sufficient in practice.
+
+---
+
+## Phase 3: Integration
+
+### T007: Doctor skill reports the active template
+
+**File(s)**: `scripts/vault-doctor.sh`, `skills/doctor/SKILL.md` (if output format is documented there)
+**Type**: Modify
+**Depends**: T005
+**Acceptance**:
+- [ ] `vault-doctor.sh` adds a new line to its output of the form:
+  - `distill template: default (bundled)` — when neither config key is set.
+  - `distill template: global: <path>` — when only `distill.template_path` is set and readable.
+  - `distill template: project-override(<slug>): <path>` — when a per-project override is set and readable. The `<slug>` here is the slug of the project doctor is run against (doctor already knows how to compute this).
+  - `distill template: configured but unreadable — falling back to default` — when the configured path fails the readable/non-empty check.
+- [ ] Doctor reuses `om_resolve_distill_template` and inspects the stderr it produces to distinguish "configured but unreadable" from the readable cases. The cleanest way: doctor calls a new thin helper `om_describe_distill_template "$slug"` that returns the descriptor string without emitting its own stderr.
+- [ ] The new line appears in the doctor output whether or not `distill.enabled` is true — an unreadable path is worth reporting even when distill is off.
+- [ ] Existing doctor output lines are unchanged in order and format.
+
+**Notes**: If FR7's Should priority is deferred in implementation, T007 can be marked complete with a no-op in doctor — but the acceptance criteria here pin the exact string format, so defer by skipping the task, not by emitting different strings.
+
+### T008: Update SKILL.md for setup (and teardown, if it mirrors config)
+
+**File(s)**: `skills/setup/SKILL.md`, `skills/teardown/SKILL.md` (read-only check)
+**Type**: Modify
+**Depends**: T001, T005
+**Acceptance**:
+- [ ] Setup SKILL.md documents the `distill.template_path` config key under a new "Customizing the distillation template" section.
+- [ ] The section describes the copy-and-edit flow: `cp <plugin-root>/templates/default-distillation.md ~/.claude/obsidian-memory/templates/my-template.md`, then edit the config to point at it.
+- [ ] The section lists the six whitelist variables and notes that `$VAR`, backticks, `$()`, and `${…}` in templates are NOT expanded.
+- [ ] The section notes that a template with a YAML frontmatter block replaces the default seven-field frontmatter.
+- [ ] Teardown SKILL.md is inspected — if it removes config keys, it is updated to also remove `distill.template_path` and `projects.overrides.<slug>.distill.*`. If teardown already removes the whole config file on uninstall (check first), no change is needed.
+
+**Notes**: Both skill docs are Markdown-only — no behavior change beyond the doctor integration in T007.
+
+---
+
+## Phase 4: BDD Testing (Required)
+
+**Every acceptance criterion MUST have a Gherkin scenario.** Step definitions live under `tests/features/steps/vault-distill.sh` (extending the existing file, not a new one).
+
+### T009: Author the BDD feature file
+
+**File(s)**: `specs/feature-make-distillation-template-configurable/feature.gherkin`
+**Type**: Create
+**Depends**: T006
+**Acceptance**:
+- [ ] The feature file contains one Scenario per requirements.md AC (AC1 through AC5).
+- [ ] Each scenario uses concrete fixture values (not placeholders like `<slug>`): a realistic slug such as `widgets`, a fixed date like `2026-04-22`, and a small transcript fixture.
+- [ ] The file includes a `Background:` block that sets up `$VAULT`, installs the plugin against a scratch `$HOME`, writes a config with `distill.enabled=true`, and seeds a minimal 2-KB transcript.
+- [ ] The feature is valid Gherkin syntax (`tests/run-bdd.sh` parses it without error — though the steps may fail until T010 lands).
+
+**Notes**: Reuse scenario-naming style from `specs/feature-session-distillation-hook/feature.gherkin` for consistency.
+
+### T010: Implement the new BDD step definitions
+
+**File(s)**: `tests/features/steps/vault-distill.sh`, `tests/fixtures/distill/v0.1-prompt.txt` (new golden file)
+**Type**: Modify (steps file) and Create (golden fixture)
+**Depends**: T001, T006, T009
+**Acceptance**:
+- [ ] New Given/When/Then steps exist for each scenario-specific phrase from T009's feature file (e.g., `a template at "$path" with body: <doc-string>`, `the prompt sent to claude -p is byte-identical to the v0.1 prompt`).
+- [ ] The golden fixture `tests/fixtures/distill/v0.1-prompt.txt` is a copy of the pre-change inline `PROMPT="..."` content (captured before T001 removes it) for use in AC2's byte-equality assertion.
+- [ ] The `claude -p` stub used by the test harness is reused unchanged — no new stubs added.
+- [ ] All 5 scenarios from the feature file pass: `tests/run-bdd.sh` exits 0 for this feature.
+- [ ] Shellcheck clean on any new step definitions.
+
+**Notes**: AC2's scenario compares the prompt string the hook sends to `claude -p`, not the final note content. The test harness already intercepts the stub's argv; extend it to log the prompt to a file the scenario can diff against the golden fixture.
+
+### T011: Author unit tests for the three new helpers
+
+**File(s)**: `tests/unit/template.bats`
+**Type**: Create
+**Depends**: T003, T004, T005
+**Acceptance**:
+- [ ] `om_render` tests cover: each of 6 whitelist vars replaced; non-whitelist `{{foo}}` preserved; `$HOME`/backticks/`$(…)`/`${…}` preserved; empty input → empty output; multi-occurrence `{{project_slug}}` all replaced; `{{project_slugger}}` not partial-matched (regex footgun guard).
+- [ ] `om_split_frontmatter` tests cover: no frontmatter → empty FM; well-formed FM → FM + body; malformed FM (open-only) → empty FM + full input; template starting with `---` followed by only `---` and nothing else (edge: FM present but body empty).
+- [ ] `om_resolve_distill_template` tests cover: all three resolution tiers; unreadable configured path falls back with one stderr line; empty configured file falls back with one stderr line; per-project override with mismatched slug is ignored; relative path in config resolves against `$HOME`.
+- [ ] `bats tests/unit/template.bats` exits 0.
+
+**Notes**: Use `$BATS_TEST_TMPDIR` as the scratch `$HOME`. Never touch the operator's real `~/.claude`.
+
+### T012: Freeze the default-template byte-identity check
+
+**File(s)**: `tests/unit/default-template.bats`
+**Type**: Create
+**Depends**: T001, T010
+**Acceptance**:
+- [ ] A single bats test asserts the SHA-256 of `templates/default-distillation.md` matches a hash literal stored in the test file. The hash is computed once from the initial check-in of T001 and pinned.
+- [ ] The test's failure message explains how to update the hash intentionally (the message names the expected file and the command `shasum -a 256 templates/default-distillation.md`).
+- [ ] `bats tests/unit/default-template.bats` exits 0 at check-in.
+
+**Notes**: This is the drift guard from design.md → Risks. Without it, a future editor can silently change the default template, breaking AC2 for every user who has not configured a template. The test is intentionally precious — it should fail loudly, and the remediation path is a deliberate hash update in the same commit as the template change.
+
+---
+
+## Dependency Graph
+
+```
+T001 ────────────────┬──▶ T010 ──▶ (uses golden fixture)
+                     │
+                     └──▶ T012
+
+T002 ──┬──▶ T003 ────┼──▶ T006 ──▶ T009 ──▶ T010
+       │             │
+       ├──▶ T004 ────┤
+       │             │
+       └──▶ T005 ────┴──▶ T007
+                     │
+                     └──▶ T008
+                     
+T003, T004, T005 ──▶ T011
+```
+
+Critical path: **T002 → T005 → T006 → T009 → T010** (the end-to-end BDD path). T001 / T011 / T012 run in parallel off the critical path.
+
+---
+
+## Change History
+
+| Issue | Date | Summary |
+|-------|------|---------|
+| #7 | 2026-04-22 | Initial feature spec |
+
+---
+
+## Validation Checklist
+
+Before moving to IMPLEMENT phase:
+
+- [x] Each task has a single responsibility
+- [x] Dependencies are correctly mapped (see Dependency Graph above)
+- [x] Tasks can be completed independently once their dependencies land (T003/T004/T005 can run in parallel after T002)
+- [x] Acceptance criteria are verifiable (every task acceptance is either a file check, a shellcheck pass, or a bats/BDD run)
+- [x] File paths reference actual project structure per `steering/structure.md` (`scripts/`, `tests/`, `skills/`, plus the new `templates/` top-level dir)
+- [x] Test tasks are included for each layer (unit: T011, T012; integration/BDD: T009, T010)
+- [x] No circular dependencies
+- [x] Tasks are in logical execution order (Setup → Backend → Integration → Testing)

--- a/templates/default-distillation.md
+++ b/templates/default-distillation.md
@@ -1,0 +1,26 @@
+You are distilling a Claude Code session transcript into a concise Obsidian note.
+
+Output ONLY the note body in Markdown. No preamble. No outer code fences.
+
+Include these sections (omit any that would be empty):
+
+## Summary
+Two or three sentences describing what the session accomplished.
+
+## Decisions
+Notable choices and the reasoning behind them.
+
+## Patterns & Gotchas
+Specific file paths, commands, identifiers, or non-obvious constraints worth remembering.
+
+## Open Threads
+What is unfinished or should be picked up next.
+
+## Tags
+A single space-separated line starting with #project/{{project_slug}}, plus 3–5 topical tags.
+
+Use Obsidian [[wiki-links]] for salient entities (files, functions, concepts). Cap the note at ~500 words.
+
+TRANSCRIPT:
+
+{{transcript}}

--- a/tests/features/steps/common.sh
+++ b/tests/features/steps/common.sh
@@ -5,9 +5,11 @@
 # Every step function is idempotent and writes only under $BATS_TEST_TMPDIR.
 
 # shellcheck shell=bash
-# shellcheck disable=SC2154,SC2153
+# shellcheck disable=SC2154,SC2153,SC2034
 # SC2154/SC2153 fire for VAULT/HOME/PLUGIN_ROOT/HELPERS_DIR — all set by
 # tests/helpers/scratch.bash and tests/run-bdd.sh before common.sh is sourced.
+# SC2034: _distill_invoke sets DISTILL_STDERR/DISTILL_RC for consumers in the
+# feature-specific step files.
 
 # shellcheck disable=SC1091
 . "$HELPERS_DIR/fake-claude.bash"
@@ -85,6 +87,35 @@ _config_get_field() {
 # cksum-based content hash of a single file.
 _hash_file() {
   [ -f "$1" ] && cksum < "$1" 2>/dev/null || true
+}
+
+# Shared distillation-test helpers. Multiple feature step files drive
+# vault-distill.sh through the same payload shape, so the fixture seed /
+# hook-invocation / note-lookup trio lives here.
+_seed_transcript() {
+  # $1 = path, $2 = target byte size. Each line is a ~260 B user JSONL entry.
+  local path="$1" size="$2"
+  mkdir -p "$(dirname "$path")"
+  : > "$path"
+  local msg i=0
+  while [ "$(wc -c < "$path" | tr -d ' ')" -lt "$size" ]; do
+    msg="$(printf '{"type":"user","message":{"content":[{"type":"text","text":"Sample message %d about config parsing with jq and file paths"}]}}' "$i")"
+    printf '%s\n' "$msg" >> "$path"
+    i=$((i + 1))
+  done
+}
+
+_distill_invoke() {
+  local t="$1" c="$2" s="$3" r="$4"
+  local payload
+  payload="$(printf '{"transcript_path":"%s","cwd":"%s","session_id":"%s","reason":"%s"}' "$t" "$c" "$s" "$r")"
+  DISTILL_STDERR="$(mktemp "$BATS_TEST_TMPDIR/distill-stderr.XXXXXX")"
+  printf '%s' "$payload" | "$PLUGIN_ROOT/scripts/vault-distill.sh" >/dev/null 2>"$DISTILL_STDERR"
+  DISTILL_RC=$?
+}
+
+_latest_note_in() {
+  find "$1" -type f -name '*.md' 2>/dev/null | sort | tail -n 1
 }
 
 # Given a scratch HOME at "$BATS_TEST_TMPDIR/home"

--- a/tests/features/steps/distill.sh
+++ b/tests/features/steps/distill.sh
@@ -7,38 +7,10 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2154,SC2153
 
-DISTILL_STDERR=""
-DISTILL_RC=0
+# DISTILL_STDERR / DISTILL_RC are populated by _distill_invoke in common.sh.
 DISTILL_TRANSCRIPT=""
 DISTILL_CWD=""
 DISTILL_SESSION_ID=""
-
-_seed_transcript() {
-  # $1 = path under $HOME/.claude/projects, $2 = target byte size
-  local path="$1" size="$2"
-  mkdir -p "$(dirname "$path")"
-  : > "$path"
-  # Each line is a valid user/assistant message JSONL entry of ~260 bytes.
-  local msg i=0
-  while [ "$(wc -c < "$path" | tr -d ' ')" -lt "$size" ]; do
-    msg="$(printf '{"type":"user","message":{"content":[{"type":"text","text":"Sample message %d about config parsing with jq and file paths"}]}}' "$i")"
-    printf '%s\n' "$msg" >> "$path"
-    i=$((i + 1))
-  done
-}
-
-_distill_invoke() {
-  local t="$1" c="$2" s="$3" r="$4"
-  local payload
-  payload="$(printf '{"transcript_path":"%s","cwd":"%s","session_id":"%s","reason":"%s"}' "$t" "$c" "$s" "$r")"
-  DISTILL_STDERR="$(mktemp "$BATS_TEST_TMPDIR/distill-stderr.XXXXXX")"
-  printf '%s' "$payload" | "$PLUGIN_ROOT/scripts/vault-distill.sh" >/dev/null 2>"$DISTILL_STDERR"
-  DISTILL_RC=$?
-}
-
-_latest_note_in() {
-  find "$1" -type f -name '*.md' 2>/dev/null | sort | tail -n 1
-}
 
 # ------------------------------------------------------------
 # Given steps

--- a/tests/features/steps/make-distillation-template-configurable.sh
+++ b/tests/features/steps/make-distillation-template-configurable.sh
@@ -45,37 +45,8 @@ STUB
   export PATH
 }
 
-_seed_transcript_min_bytes() {
-  # $1 = destination path, $2 = target byte count. Each line is a valid
-  # user-message JSONL entry so vault-distill.sh's jq filter produces non-
-  # empty CONVO output from it.
-  local path="$1" size="$2"
-  mkdir -p "$(dirname "$path")"
-  : > "$path"
-  local msg i=0
-  while [ "$(wc -c < "$path" | tr -d ' ')" -lt "$size" ]; do
-    msg="$(printf '{"type":"user","message":{"content":[{"type":"text","text":"Sample message %d about config parsing with jq and file paths"}]}}' "$i")"
-    printf '%s\n' "$msg" >> "$path"
-    i=$((i + 1))
-  done
-}
-
-_invoke_distill_hook() {
-  # $1 = cwd, $2 = session_id. Uses the pre-seeded DISTILL_TRANSCRIPT.
-  local cwd="$1" sid="$2"
-  local payload
-  payload="$(printf '{"transcript_path":"%s","cwd":"%s","session_id":"%s","reason":"clear"}' \
-    "$DISTILL_TRANSCRIPT" "$cwd" "$sid")"
-  DISTILL_STDERR="$(mktemp "$BATS_TEST_TMPDIR/distill-stderr.XXXXXX")"
-  printf '%s' "$payload" | "$PLUGIN_ROOT/scripts/vault-distill.sh" >/dev/null 2>"$DISTILL_STDERR"
-  DISTILL_RC=$?
-}
-
-_latest_note_under() {
-  # $1 = sessions dir (may include trailing slash)
-  local dir="${1%/}"
-  find "$dir" -type f -name '*.md' 2>/dev/null | sort | tail -n 1
-}
+# _seed_transcript, _distill_invoke, _latest_note_in live in common.sh.
+_latest_note_under() { _latest_note_in "${1%/}"; }
 
 _nth_line() {
   # $1 = file, $2 = line number (1-indexed)
@@ -100,7 +71,7 @@ given_a_prompt_capturing_claude_stub_is_installed_at() {
 given_a_transcript_at_of_size_5000_bytes() {
   DISTILL_TRANSCRIPT="$1"
   DISTILL_SESSION_ID="widgets-session"
-  _seed_transcript_min_bytes "$DISTILL_TRANSCRIPT" 5000
+  _seed_transcript "$DISTILL_TRANSCRIPT" 5000
 }
 
 given_a_readable_template_at_with_content() {
@@ -141,7 +112,7 @@ given_the_config_sets_to_the_bundled_default_template() {
 when_sessionend_fires_with_cwd_session_id() {
   local cwd="$1" sid="$2"
   DISTILL_SESSION_ID="$sid"
-  _invoke_distill_hook "$cwd" "$sid"
+  _distill_invoke "$DISTILL_TRANSCRIPT" "$cwd" "$sid" "clear"
 }
 
 # ------------------------------------------------------------
@@ -166,17 +137,10 @@ then_the_captured_prompt_starts_with_followed_by_today_s_utc_date() {
 
 then_the_captured_prompt_contains() {
   local needle="$1"
-  local today
-  today="$(date -u +%Y-%m-%d)"
-  # Two-arg form used by scenarios that tack on "followed by today's UTC
-  # date" — the second literal is dropped by _normalize_step into the
-  # function name, so only the needle prefix arrives as $1.
   local captured
   captured="$(_captured_prompt_contents)" || return 1
-  # Case 1: <prefix> is followed immediately by today's date.
   case "$captured" in
-    *"${needle}${today}"*) return 0 ;;
-    *"${needle}"*) return 0 ;;
+    *"$needle"*) return 0 ;;
   esac
   printf 'captured prompt did not contain: %s\n' "$needle" >&2
   return 1

--- a/tests/features/steps/make-distillation-template-configurable.sh
+++ b/tests/features/steps/make-distillation-template-configurable.sh
@@ -1,0 +1,390 @@
+# tests/features/steps/make-distillation-template-configurable.sh — step
+# definitions for specs/feature-make-distillation-template-configurable/
+# feature.gherkin (#7).
+#
+# Exercises the configurable-template surface end-to-end against the scratch
+# vault. Most scenarios install a prompt-capturing "claude" stub (on top of
+# the fixed-output stub from tests/helpers/fake-claude.bash) so the exact
+# prompt argv passed to claude -p can be asserted byte-for-byte.
+
+# shellcheck shell=bash
+# shellcheck disable=SC2154,SC2153,SC2034
+# SC2154/SC2153: HOME/VAULT/PLUGIN_ROOT/BATS_TEST_TMPDIR/CAPTURED_PROMPT come
+# from tests/helpers/scratch.bash, tests/features/steps/common.sh, and this
+# file's own setup steps. SC2034: module-scoped state (DISTILL_SESSION_ID)
+# is read by step callbacks the dispatcher invokes dynamically.
+
+DISTILL_STDERR=""
+DISTILL_RC=0
+DISTILL_TRANSCRIPT=""
+DISTILL_SESSION_ID=""
+CAPTURED_PROMPT=""
+
+_prompt_capture_path() {
+  printf '%s' "${CAPTURED_PROMPT:-$BATS_TEST_TMPDIR/captured-prompt.txt}"
+}
+
+_install_prompt_capturing_stub() {
+  # Overwrites tests/helpers/fake-claude.bash's stub so we can observe the
+  # exact prompt argv the hook passes to `claude -p`. The body echoed back
+  # is still deterministic ("STUBBED_NOTE_BODY") so the note content is
+  # irrelevant to prompt-side assertions.
+  local bindir="${1:-$BATS_TEST_TMPDIR/bin}"
+  CAPTURED_PROMPT="$BATS_TEST_TMPDIR/captured-prompt.txt"
+  export CAPTURED_PROMPT
+  mkdir -p "$bindir"
+  cat > "$bindir/claude" <<STUB
+#!/usr/bin/env bash
+# Prompt-capturing claude stub for issue-#7 scenarios. argv[1] is "-p";
+# argv[2] is the prompt string the hook composed after template rendering.
+printf '%s' "\$2" > "$CAPTURED_PROMPT"
+printf '%s\n' "STUBBED_NOTE_BODY"
+STUB
+  chmod +x "$bindir/claude"
+  PATH="$bindir:$PATH"
+  export PATH
+}
+
+_seed_transcript_min_bytes() {
+  # $1 = destination path, $2 = target byte count. Each line is a valid
+  # user-message JSONL entry so vault-distill.sh's jq filter produces non-
+  # empty CONVO output from it.
+  local path="$1" size="$2"
+  mkdir -p "$(dirname "$path")"
+  : > "$path"
+  local msg i=0
+  while [ "$(wc -c < "$path" | tr -d ' ')" -lt "$size" ]; do
+    msg="$(printf '{"type":"user","message":{"content":[{"type":"text","text":"Sample message %d about config parsing with jq and file paths"}]}}' "$i")"
+    printf '%s\n' "$msg" >> "$path"
+    i=$((i + 1))
+  done
+}
+
+_invoke_distill_hook() {
+  # $1 = cwd, $2 = session_id. Uses the pre-seeded DISTILL_TRANSCRIPT.
+  local cwd="$1" sid="$2"
+  local payload
+  payload="$(printf '{"transcript_path":"%s","cwd":"%s","session_id":"%s","reason":"clear"}' \
+    "$DISTILL_TRANSCRIPT" "$cwd" "$sid")"
+  DISTILL_STDERR="$(mktemp "$BATS_TEST_TMPDIR/distill-stderr.XXXXXX")"
+  printf '%s' "$payload" | "$PLUGIN_ROOT/scripts/vault-distill.sh" >/dev/null 2>"$DISTILL_STDERR"
+  DISTILL_RC=$?
+}
+
+_latest_note_under() {
+  # $1 = sessions dir (may include trailing slash)
+  local dir="${1%/}"
+  find "$dir" -type f -name '*.md' 2>/dev/null | sort | tail -n 1
+}
+
+_nth_line() {
+  # $1 = file, $2 = line number (1-indexed)
+  awk -v n="$2" 'NR == n { print; exit }' "$1"
+}
+
+_captured_prompt_contents() {
+  local p
+  p="$(_prompt_capture_path)"
+  [ -f "$p" ] || return 1
+  cat "$p"
+}
+
+# ------------------------------------------------------------
+# Given steps
+# ------------------------------------------------------------
+
+given_a_prompt_capturing_claude_stub_is_installed_at() {
+  _install_prompt_capturing_stub "$1"
+}
+
+given_a_transcript_at_of_size_5000_bytes() {
+  DISTILL_TRANSCRIPT="$1"
+  DISTILL_SESSION_ID="widgets-session"
+  _seed_transcript_min_bytes "$DISTILL_TRANSCRIPT" 5000
+}
+
+given_a_readable_template_at_with_content() {
+  local path="$1" content="$2"
+  mkdir -p "$(dirname "$path")"
+  printf '%b' "$content" > "$path"
+}
+
+given_an_empty_file_at() {
+  local path="$1"
+  mkdir -p "$(dirname "$path")"
+  : > "$path"
+}
+
+given_the_config_sets_to() {
+  local key="$1" val="$2"
+  local cfg="$HOME/.claude/obsidian-memory/config.json"
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  if jq --arg f "$key" --arg v "$val" 'setpath($f | split("."); $v)' "$cfg" > "$tmp"; then
+    mv "$tmp" "$cfg"
+  else
+    rm -f "$tmp"
+    return 1
+  fi
+}
+
+given_the_config_sets_to_the_bundled_default_template() {
+  local key="$1"
+  local bundled="$PLUGIN_ROOT/templates/default-distillation.md"
+  given_the_config_sets_to "$key" "$bundled"
+}
+
+# ------------------------------------------------------------
+# When steps
+# ------------------------------------------------------------
+
+when_sessionend_fires_with_cwd_session_id() {
+  local cwd="$1" sid="$2"
+  DISTILL_SESSION_ID="$sid"
+  _invoke_distill_hook "$cwd" "$sid"
+}
+
+# ------------------------------------------------------------
+# Then steps — captured prompt
+# ------------------------------------------------------------
+
+then_the_captured_prompt_starts_with_followed_by_today_s_utc_date() {
+  local prefix="$1"
+  local today
+  today="$(date -u +%Y-%m-%d)"
+  local captured
+  captured="$(_captured_prompt_contents)" || return 1
+  case "$captured" in
+    "${prefix}${today}"*) return 0 ;;
+    *)
+      printf 'expected prompt to start with "%s%s", got head:\n%s\n' \
+        "$prefix" "$today" "$(printf '%s' "$captured" | head -c 200)" >&2
+      return 1
+      ;;
+  esac
+}
+
+then_the_captured_prompt_contains() {
+  local needle="$1"
+  local today
+  today="$(date -u +%Y-%m-%d)"
+  # Two-arg form used by scenarios that tack on "followed by today's UTC
+  # date" — the second literal is dropped by _normalize_step into the
+  # function name, so only the needle prefix arrives as $1.
+  local captured
+  captured="$(_captured_prompt_contents)" || return 1
+  # Case 1: <prefix> is followed immediately by today's date.
+  case "$captured" in
+    *"${needle}${today}"*) return 0 ;;
+    *"${needle}"*) return 0 ;;
+  esac
+  printf 'captured prompt did not contain: %s\n' "$needle" >&2
+  return 1
+}
+
+then_the_captured_prompt_contains_followed_by_today_s_utc_date() {
+  local prefix="$1"
+  local today
+  today="$(date -u +%Y-%m-%d)"
+  local captured
+  captured="$(_captured_prompt_contents)" || return 1
+  case "$captured" in
+    *"${prefix}${today}"*) return 0 ;;
+  esac
+  printf 'captured prompt missing "%s%s"\n' "$prefix" "$today" >&2
+  return 1
+}
+
+then_the_captured_prompt_contains_the_literal_substring() {
+  local needle="$1"
+  local captured
+  captured="$(_captured_prompt_contents)" || return 1
+  case "$captured" in
+    *"$needle"*) return 0 ;;
+  esac
+  printf 'captured prompt missing literal substring: %s\n' "$needle" >&2
+  return 1
+}
+
+then_the_captured_prompt_does_not_contain_the_bare_token() {
+  local token="$1"
+  local captured
+  captured="$(_captured_prompt_contents)" || return 1
+  case "$captured" in
+    *"$token"*)
+      printf 'captured prompt unexpectedly contained bare token: %s\n' "$token" >&2
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+then_the_captured_prompt_does_not_contain_at_the_start() {
+  local token="$1"
+  local captured
+  captured="$(_captured_prompt_contents)" || return 1
+  # printf %b to interpret \n in the Gherkin literal (e.g., "---\n").
+  local decoded
+  decoded="$(printf '%b' "$token")"
+  case "$captured" in
+    "$decoded"*)
+      printf 'captured prompt unexpectedly started with: %q\n' "$decoded" >&2
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+then_the_captured_prompt_prefix_matches_the_golden_fixture() {
+  local rel="$1"
+  local fixture="$PLUGIN_ROOT/$rel"
+  local captured
+  captured="$(_prompt_capture_path)"
+  [ -f "$fixture" ] || { printf 'missing fixture: %s\n' "$fixture" >&2; return 1; }
+  [ -f "$captured" ] || { printf 'no captured prompt\n' >&2; return 1; }
+  local fix_size
+  fix_size="$(wc -c < "$fixture" | tr -d ' ')"
+  head -c "$fix_size" "$captured" | cmp -s - "$fixture" || {
+    printf 'captured prompt prefix did not match %s (first %s bytes)\n' "$fixture" "$fix_size" >&2
+    printf '--- expected head ---\n' >&2
+    head -c 200 "$fixture" >&2
+    printf '\n--- actual head ---\n' >&2
+    head -c 200 "$captured" >&2
+    printf '\n' >&2
+    return 1
+  }
+}
+
+# ------------------------------------------------------------
+# Then steps — session notes
+# ------------------------------------------------------------
+
+then_a_session_note_file_exists_under() {
+  local dir="$1"
+  local f
+  f="$(_latest_note_under "$dir")"
+  [ -n "$f" ] && [ -f "$f" ]
+}
+
+then_the_latest_session_note_under_starts_with_a_yaml_frontmatter_block_with_keys_in_order() {
+  local dir="$1" keys_csv="$2"
+  local f
+  f="$(_latest_note_under "$dir")"
+  [ -n "$f" ] || { printf 'no note under %s\n' "$dir" >&2; return 1; }
+  local actual_keys
+  actual_keys="$(awk 'NR == 1 && /^---/ { flag = 1; next }
+                     flag && /^---/ { exit }
+                     flag { sub(/:.*/, ""); print }' "$f" | paste -sd ',' -)"
+  if [ "$actual_keys" != "$keys_csv" ]; then
+    printf 'frontmatter keys mismatch:\n  expected: %s\n  actual:   %s\n' \
+      "$keys_csv" "$actual_keys" >&2
+    return 1
+  fi
+}
+
+then_the_index_md_line_under_matches_the_v0_1_pattern() {
+  local path="$1" pattern="$2"
+  [ -f "$path" ] || { printf 'missing: %s\n' "$path" >&2; return 1; }
+  grep -qE "$pattern" "$path" || {
+    printf 'no line in %s matched: %s\n' "$path" "$pattern" >&2
+    tail -5 "$path" >&2
+    return 1
+  }
+}
+
+then_the_hook_stderr_contains_exactly_one_line_matching() {
+  local pattern="$1"
+  [ -f "$DISTILL_STDERR" ] || { printf 'no stderr log\n' >&2; return 1; }
+  local n
+  n="$(grep -cE "$pattern" "$DISTILL_STDERR" 2>/dev/null || printf 0)"
+  if [ "$n" -ne 1 ]; then
+    printf 'expected exactly one stderr line matching:\n  %s\nfound %d. stderr was:\n' \
+      "$pattern" "$n" >&2
+    cat "$DISTILL_STDERR" >&2
+    return 1
+  fi
+}
+
+then_the_latest_session_note_under_starts_with_exactly_5_frontmatter_lines_beginning_with_and_ending_with() {
+  # args: <sessions-dir>, <open-delim>, <close-delim>
+  # "<count>" appears between quoted literals in the Gherkin line and gets
+  # stripped by _normalize_step — we validate structure rather than count.
+  local dir="$1" open_delim="$2" close_delim="$3"
+  local f
+  f="$(_latest_note_under "$dir")"
+  [ -n "$f" ] || { printf 'no note under %s\n' "$dir" >&2; return 1; }
+  local first_line
+  first_line="$(head -n 1 "$f")"
+  [ "$first_line" = "$open_delim" ] || {
+    printf 'first line was %q, expected %q\n' "$first_line" "$open_delim" >&2
+    return 1
+  }
+  # Find the closing delimiter on or after line 2.
+  awk -v d="$close_delim" '
+    NR == 1 { next }
+    $0 == d { print NR; found = 1; exit }
+    END { if (!found) exit 1 }
+  ' "$f" >/dev/null || {
+    printf 'no closing %s delimiter found after line 1 in %s\n' "$close_delim" "$f" >&2
+    return 1
+  }
+}
+
+then_the_latest_session_note_first_frontmatter_line_is() {
+  local expected="$1"
+  local f
+  f="$(find "$VAULT/claude-memory/sessions" -type f -name '*.md' 2>/dev/null | sort | tail -n 1)"
+  [ -n "$f" ] || return 1
+  [ "$(head -n 1 "$f")" = "$expected" ]
+}
+
+then_the_latest_session_note_second_frontmatter_line_starts_with() {
+  local prefix="$1"
+  local f
+  f="$(find "$VAULT/claude-memory/sessions" -type f -name '*.md' 2>/dev/null | sort | tail -n 1)"
+  [ -n "$f" ] || return 1
+  local line
+  line="$(_nth_line "$f" 2)"
+  case "$line" in
+    "$prefix"*) return 0 ;;
+    *)
+      printf 'line 2 was %q, expected prefix %q\n' "$line" "$prefix" >&2
+      return 1
+      ;;
+  esac
+}
+
+then_the_latest_session_note_third_frontmatter_line_is() {
+  local expected="$1"
+  local f
+  f="$(find "$VAULT/claude-memory/sessions" -type f -name '*.md' 2>/dev/null | sort | tail -n 1)"
+  [ -n "$f" ] || return 1
+  [ "$(_nth_line "$f" 3)" = "$expected" ]
+}
+
+then_the_latest_session_note_fourth_frontmatter_line_is() {
+  local expected="$1"
+  local f
+  f="$(find "$VAULT/claude-memory/sessions" -type f -name '*.md' 2>/dev/null | sort | tail -n 1)"
+  [ -n "$f" ] || return 1
+  [ "$(_nth_line "$f" 4)" = "$expected" ]
+}
+
+then_the_latest_session_note_does_not_contain_a_second_frontmatter_block_with() {
+  local needle="$1"
+  local f
+  f="$(find "$VAULT/claude-memory/sessions" -type f -name '*.md' 2>/dev/null | sort | tail -n 1)"
+  [ -n "$f" ] || return 1
+  if grep -qF -- "$needle" "$f"; then
+    printf 'session note unexpectedly contained: %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------
+# Then steps — hook exit
+# ------------------------------------------------------------
+
+then_the_hook_exit_code_is_0() {
+  [ "$DISTILL_RC" = 0 ]
+}

--- a/tests/features/steps/make-distillation-template-configurable.sh
+++ b/tests/features/steps/make-distillation-template-configurable.sh
@@ -297,7 +297,7 @@ then_the_latest_session_note_under_starts_with_exactly_5_frontmatter_lines_begin
 then_the_latest_session_note_first_frontmatter_line_is() {
   local expected="$1"
   local f
-  f="$(find "$VAULT/claude-memory/sessions" -type f -name '*.md' 2>/dev/null | sort | tail -n 1)"
+  f="$(_latest_note_under "$VAULT/claude-memory/sessions")"
   [ -n "$f" ] || return 1
   [ "$(head -n 1 "$f")" = "$expected" ]
 }
@@ -305,7 +305,7 @@ then_the_latest_session_note_first_frontmatter_line_is() {
 then_the_latest_session_note_second_frontmatter_line_starts_with() {
   local prefix="$1"
   local f
-  f="$(find "$VAULT/claude-memory/sessions" -type f -name '*.md' 2>/dev/null | sort | tail -n 1)"
+  f="$(_latest_note_under "$VAULT/claude-memory/sessions")"
   [ -n "$f" ] || return 1
   local line
   line="$(_nth_line "$f" 2)"
@@ -321,7 +321,7 @@ then_the_latest_session_note_second_frontmatter_line_starts_with() {
 then_the_latest_session_note_third_frontmatter_line_is() {
   local expected="$1"
   local f
-  f="$(find "$VAULT/claude-memory/sessions" -type f -name '*.md' 2>/dev/null | sort | tail -n 1)"
+  f="$(_latest_note_under "$VAULT/claude-memory/sessions")"
   [ -n "$f" ] || return 1
   [ "$(_nth_line "$f" 3)" = "$expected" ]
 }
@@ -329,7 +329,7 @@ then_the_latest_session_note_third_frontmatter_line_is() {
 then_the_latest_session_note_fourth_frontmatter_line_is() {
   local expected="$1"
   local f
-  f="$(find "$VAULT/claude-memory/sessions" -type f -name '*.md' 2>/dev/null | sort | tail -n 1)"
+  f="$(_latest_note_under "$VAULT/claude-memory/sessions")"
   [ -n "$f" ] || return 1
   [ "$(_nth_line "$f" 4)" = "$expected" ]
 }
@@ -337,7 +337,7 @@ then_the_latest_session_note_fourth_frontmatter_line_is() {
 then_the_latest_session_note_does_not_contain_a_second_frontmatter_block_with() {
   local needle="$1"
   local f
-  f="$(find "$VAULT/claude-memory/sessions" -type f -name '*.md' 2>/dev/null | sort | tail -n 1)"
+  f="$(_latest_note_under "$VAULT/claude-memory/sessions")"
   [ -n "$f" ] || return 1
   if grep -qF -- "$needle" "$f"; then
     printf 'session note unexpectedly contained: %s\n' "$needle" >&2

--- a/tests/fixtures/distill/v0.1-prompt.txt
+++ b/tests/fixtures/distill/v0.1-prompt.txt
@@ -1,0 +1,25 @@
+You are distilling a Claude Code session transcript into a concise Obsidian note.
+
+Output ONLY the note body in Markdown. No preamble. No outer code fences.
+
+Include these sections (omit any that would be empty):
+
+## Summary
+Two or three sentences describing what the session accomplished.
+
+## Decisions
+Notable choices and the reasoning behind them.
+
+## Patterns & Gotchas
+Specific file paths, commands, identifiers, or non-obvious constraints worth remembering.
+
+## Open Threads
+What is unfinished or should be picked up next.
+
+## Tags
+A single space-separated line starting with #project/widgets, plus 3–5 topical tags.
+
+Use Obsidian [[wiki-links]] for salient entities (files, functions, concepts). Cap the note at ~500 words.
+
+TRANSCRIPT:
+

--- a/tests/unit/default-template.bats
+++ b/tests/unit/default-template.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+# tests/unit/default-template.bats — drift guard for the bundled default
+# distillation template.
+#
+# The SHA-256 below is the initial check-in hash for templates/default-
+# distillation.md. This test fails loudly whenever that file changes. The
+# failure is intentional: `vault-distill.sh` has no inline fallback prompt
+# anymore, so a silent edit to the bundled template would change the
+# observable prompt text for every user who has not configured their own
+# `distill.template_path`. If the change is deliberate, update the hash in
+# the same commit as the template change.
+#
+# To compute a fresh hash:
+#
+#   shasum -a 256 templates/default-distillation.md
+#
+# See specs/feature-make-distillation-template-configurable/ (#7) for
+# the layering that makes this file the sole source of truth for the
+# v0.1 distillation prompt.
+
+setup() {
+  load '../helpers/scratch'
+  TEMPLATE="$PLUGIN_ROOT/templates/default-distillation.md"
+  export TEMPLATE
+  EXPECTED_HASH="fe1f1d947291fcb7d4fc87dc87428af890f6a5c2c26acec3793664e402bec6f7"
+  export EXPECTED_HASH
+}
+
+teardown() { assert_home_untouched; }
+
+@test "default-distillation.md: bundled template exists and is non-empty" {
+  [ -r "$TEMPLATE" ]
+  [ -s "$TEMPLATE" ]
+}
+
+@test "default-distillation.md: SHA-256 matches the pinned hash (drift guard)" {
+  local actual
+  actual="$(shasum -a 256 "$TEMPLATE" | awk '{print $1}')"
+  if [ "$actual" != "$EXPECTED_HASH" ]; then
+    printf '\nDefault distillation template has drifted from the pinned hash.\n' >&2
+    printf '  file:     %s\n' "$TEMPLATE" >&2
+    printf '  expected: %s\n' "$EXPECTED_HASH" >&2
+    printf '  actual:   %s\n' "$actual" >&2
+    printf '\nIf the change is intentional, update EXPECTED_HASH in this test.\n' >&2
+    printf 'Compute the new value with:\n' >&2
+    printf '  shasum -a 256 %s\n\n' "$TEMPLATE" >&2
+    return 1
+  fi
+}

--- a/tests/unit/template.bats
+++ b/tests/unit/template.bats
@@ -1,0 +1,324 @@
+#!/usr/bin/env bats
+
+# tests/unit/template.bats — unit tests for the configurable-template helpers
+# added in issue #7: om_render, om_split_frontmatter, om_resolve_distill_template.
+#
+# Each test sources scripts/_common.sh in a fresh subshell with a scratch HOME
+# so the operator's real ~/.claude/obsidian-memory/config.json is never read.
+
+setup() {
+  load '../helpers/scratch'
+  CONFIG="$HOME/.claude/obsidian-memory/config.json"
+  export CONFIG
+  mkdir -p "$HOME/.claude/obsidian-memory"
+  COMMON="$PLUGIN_ROOT/scripts/_common.sh"
+  export COMMON
+  BUNDLED="$PLUGIN_ROOT/templates/default-distillation.md"
+  export BUNDLED
+}
+
+teardown() { assert_home_untouched; }
+
+_write_min_config() {
+  cat > "$CONFIG" <<EOF
+{
+  "vaultPath": "$VAULT",
+  "rag": { "enabled": true },
+  "distill": { "enabled": true },
+  "projects": { "mode": "all", "excluded": [], "allowed": [] }
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# om_render — whitelisted variable substitution
+# ---------------------------------------------------------------------------
+
+@test "om_render: replaces each of the six whitelisted tokens" {
+  run bash -c '
+    . "$0"
+    SLUG=widgets NOW_DATE=2026-04-22 NOW_TIME=12:34:56 SESSION_ID=abc \
+      TRANSCRIPT=/tmp/t.jsonl CONVO="USER-BODY"
+    om_render "# {{project_slug}} on {{date}} at {{time}} session {{session_id}} from {{transcript_path}}
+{{transcript}}"
+  ' "$COMMON"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"# widgets on 2026-04-22 at 12:34:56 session abc from /tmp/t.jsonl"* ]]
+  [[ "$output" == *"USER-BODY"* ]]
+}
+
+@test "om_render: non-whitelisted {{foo}} tokens pass through verbatim" {
+  run bash -c '. "$0"; SLUG=x om_render "{{user_email}} and {{custom_thing}}"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"{{user_email}}"* ]]
+  [[ "$output" == *"{{custom_thing}}"* ]]
+}
+
+@test "om_render: shell-looking syntax is preserved literally" {
+  # Single-quote to protect $HOME from bash expansion before om_render sees it.
+  run bash -c '. "$0"; SLUG=x om_render "$1"' "$COMMON" \
+    '$HOME `whoami` $(date) ${PATH} — all literal'
+  [ "$status" -eq 0 ]
+  [ "$output" = '$HOME `whoami` $(date) ${PATH} — all literal' ]
+}
+
+@test "om_render: empty input returns empty output" {
+  run bash -c '. "$0"; SLUG=x om_render ""' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "om_render: replaces every occurrence of {{project_slug}}" {
+  run bash -c '. "$0"; SLUG=widgets om_render "{{project_slug}}-{{project_slug}}-{{project_slug}}"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "widgets-widgets-widgets" ]
+}
+
+@test "om_render: regex footgun — {{project_slugger}} is NOT partial-matched" {
+  run bash -c '. "$0"; SLUG=widgets om_render "{{project_slugger}} vs {{project_slug}}"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"{{project_slugger}}"* ]]
+  [[ "$output" == *"widgets"* ]]
+  # The "ger" suffix must NOT have been silently eaten.
+  [[ "$output" == *"{{project_slugger}} vs widgets"* ]]
+}
+
+@test "om_render: stray {{ or }} braces outside whitelisted token pass through" {
+  run bash -c '. "$0"; SLUG=widgets om_render "open {{ only and close }} only"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "open {{ only and close }} only" ]
+}
+
+# ---------------------------------------------------------------------------
+# om_split_frontmatter — YAML frontmatter detection and split
+# ---------------------------------------------------------------------------
+
+@test "om_split_frontmatter: no frontmatter → empty FM, full body" {
+  run bash -c '
+    . "$0"
+    out="$(om_split_frontmatter "# body only\nline two"; printf x)"
+    out="${out%x}"
+    # field 1 before 0x1e is FM; field 2 after is body.
+    fm="${out%%$(printf "\x1e")*}"
+    body="${out#*$(printf "\x1e")}"
+    printf "FM=[%s]\nBODY=[%s]" "$fm" "$body"
+  ' "$COMMON"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FM=[]"* ]]
+  [[ "$output" == *"BODY=[# body only"* ]]
+}
+
+@test "om_split_frontmatter: well-formed frontmatter is captured fully" {
+  run bash -c '
+    . "$0"
+    input="$(printf -- "---\ntitle: hello\ntags: [a]\n---\n\n# Heading\nbody")"
+    out="$(om_split_frontmatter "$input"; printf x)"
+    out="${out%x}"
+    fm="${out%%$(printf "\x1e")*}"
+    body="${out#*$(printf "\x1e")}"
+    printf "FM=<<%s>>\nBODY=<<%s>>" "$fm" "$body"
+  ' "$COMMON"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FM=<<---"* ]]
+  [[ "$output" == *"title: hello"* ]]
+  [[ "$output" == *"BODY=<<"* ]]
+  [[ "$output" == *"# Heading"* ]]
+}
+
+@test "om_split_frontmatter: malformed (opening --- without closing) → no FM, full body" {
+  run bash -c '
+    . "$0"
+    input="$(printf -- "---\ntitle: x\nno closer here")"
+    out="$(om_split_frontmatter "$input"; printf x)"
+    out="${out%x}"
+    fm="${out%%$(printf "\x1e")*}"
+    printf "FM=[%s]" "$fm"
+  ' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "FM=[]" ]
+}
+
+@test "om_split_frontmatter: frontmatter-only template (empty body after closing ---)" {
+  run bash -c '
+    . "$0"
+    input="$(printf -- "---\ntitle: x\n---")"
+    out="$(om_split_frontmatter "$input"; printf x)"
+    out="${out%x}"
+    fm="${out%%$(printf "\x1e")*}"
+    body="${out#*$(printf "\x1e")}"
+    printf "FM_HAS_DELIM=%s\nBODY_LEN=%d" \
+      "$(printf "%s" "$fm" | grep -c "^---$")" "${#body}"
+  ' "$COMMON"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"FM_HAS_DELIM=2"* ]]
+  [[ "$output" == *"BODY_LEN=0"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# om_resolve_distill_template — resolution + fallback + stderr logging
+# ---------------------------------------------------------------------------
+
+@test "om_resolve_distill_template: no config → bundled default" {
+  rm -f "$CONFIG"
+  run bash -c '. "$0"; om_resolve_distill_template "any-slug"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$BUNDLED" ]
+}
+
+@test "om_resolve_distill_template: no template_path set → bundled default" {
+  _write_min_config
+  run bash -c '. "$0"; om_resolve_distill_template "any-slug"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$BUNDLED" ]
+}
+
+@test "om_resolve_distill_template: readable global template wins over default" {
+  _write_min_config
+  local tpl="$BATS_TEST_TMPDIR/my-template.md"
+  printf 'some content\n' > "$tpl"
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  jq --arg p "$tpl" '.distill.template_path = $p' "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+
+  run bash -c '. "$0"; om_resolve_distill_template "any-slug"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$tpl" ]
+}
+
+@test "om_resolve_distill_template: per-project override wins over global" {
+  _write_min_config
+  local g="$BATS_TEST_TMPDIR/global.md"
+  local o="$BATS_TEST_TMPDIR/override.md"
+  printf 'g\n' > "$g"
+  printf 'o\n' > "$o"
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  jq --arg g "$g" --arg o "$o" \
+    '.distill.template_path = $g
+     | .projects.overrides = {"widgets": {"distill": {"template_path": $o}}}' \
+    "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+
+  run bash -c '. "$0"; om_resolve_distill_template "widgets"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$o" ]
+}
+
+@test "om_resolve_distill_template: mismatched per-project slug falls through to global" {
+  _write_min_config
+  local g="$BATS_TEST_TMPDIR/global.md"
+  local o="$BATS_TEST_TMPDIR/override.md"
+  printf 'g\n' > "$g"
+  printf 'o\n' > "$o"
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  jq --arg g "$g" --arg o "$o" \
+    '.distill.template_path = $g
+     | .projects.overrides = {"widgets": {"distill": {"template_path": $o}}}' \
+    "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+
+  run bash -c '. "$0"; om_resolve_distill_template "other-project"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$g" ]
+}
+
+@test "om_resolve_distill_template: unreadable global template → one stderr line + bundled default" {
+  _write_min_config
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  jq '.distill.template_path = "/nope/does-not-exist.md"' "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+
+  run bash -c '. "$0"; om_resolve_distill_template "any-slug" 2>&1 >/dev/null' "$COMMON"
+  [[ "$output" == *"distill.template_path=/nope/does-not-exist.md unreadable; falling back to default template"* ]]
+
+  run bash -c '. "$0"; om_resolve_distill_template "any-slug" 2>/dev/null' "$COMMON"
+  [ "$output" = "$BUNDLED" ]
+}
+
+@test "om_resolve_distill_template: empty configured file → one stderr line + bundled default" {
+  _write_min_config
+  local tpl="$BATS_TEST_TMPDIR/empty.md"
+  : > "$tpl"
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  jq --arg p "$tpl" '.distill.template_path = $p' "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+
+  run bash -c '. "$0"; om_resolve_distill_template "any-slug" 2>&1 >/dev/null' "$COMMON"
+  [[ "$output" == *"unreadable; falling back to default template"* ]]
+
+  run bash -c '. "$0"; om_resolve_distill_template "any-slug" 2>/dev/null' "$COMMON"
+  [ "$output" = "$BUNDLED" ]
+}
+
+@test "om_resolve_distill_template: unreadable per-project override → project-scoped stderr line" {
+  _write_min_config
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  jq '.projects.overrides = {"widgets": {"distill": {"template_path": "/nope/override.md"}}}' \
+    "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+
+  run bash -c '. "$0"; om_resolve_distill_template "widgets" 2>&1 >/dev/null' "$COMMON"
+  [[ "$output" == *"projects.overrides.widgets.distill.template_path=/nope/override.md unreadable"* ]]
+}
+
+@test "om_resolve_distill_template: relative config path is resolved against \$HOME" {
+  _write_min_config
+  mkdir -p "$HOME/.claude/obsidian-memory/templates"
+  printf 'tpl\n' > "$HOME/.claude/obsidian-memory/templates/rel.md"
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  jq '.distill.template_path = ".claude/obsidian-memory/templates/rel.md"' \
+    "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+
+  run bash -c '. "$0"; om_resolve_distill_template "any"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME/.claude/obsidian-memory/templates/rel.md" ]
+}
+
+# ---------------------------------------------------------------------------
+# om_describe_distill_template — doctor-oriented descriptor (no stderr)
+# ---------------------------------------------------------------------------
+
+@test "om_describe_distill_template: no config key → 'default (bundled)'" {
+  _write_min_config
+  run bash -c '. "$0"; om_describe_distill_template "any"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "default (bundled)" ]
+}
+
+@test "om_describe_distill_template: readable global path → 'global: <path>'" {
+  _write_min_config
+  local tpl="$BATS_TEST_TMPDIR/mine.md"
+  printf 'tpl\n' > "$tpl"
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  jq --arg p "$tpl" '.distill.template_path = $p' "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+
+  run bash -c '. "$0"; om_describe_distill_template "any"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "global: $tpl" ]
+}
+
+@test "om_describe_distill_template: readable per-project → 'project-override(<slug>): <path>'" {
+  _write_min_config
+  local tpl="$BATS_TEST_TMPDIR/override.md"
+  printf 'tpl\n' > "$tpl"
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  jq --arg p "$tpl" '.projects.overrides = {"widgets": {"distill": {"template_path": $p}}}' \
+    "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+
+  run bash -c '. "$0"; om_describe_distill_template "widgets"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [ "$output" = "project-override(widgets): $tpl" ]
+}
+
+@test "om_describe_distill_template: unreadable configured path → 'configured but unreadable'" {
+  _write_min_config
+  local tmp
+  tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+  jq '.distill.template_path = "/nope/absent.md"' "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+
+  run bash -c '. "$0"; om_describe_distill_template "any"' "$COMMON"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"configured but unreadable"* ]]
+}


### PR DESCRIPTION
## Summary

Closes #7

- Extracts the hardcoded distillation prompt from `vault-distill.sh` into a bundled default template (`templates/default-distillation.md`) and adds `distill.template_path` / `projects.<slug>.overrides.template_path` config keys so users can supply their own Markdown template.
- Safe variable substitution (`{{project_slug}}`, `{{date}}`, `{{time}}`, `{{session_id}}`, `{{transcript_path}}`, `{{transcript}}`) via `jq gsub` — no `eval`, no `envsubst`, no shell expansion of template content.
- Missing/unreadable template falls back to the bundled default with a single `stderr` log line (never silently drops the session note).
- Custom frontmatter in the template replaces the hook's default seven-field YAML block; if absent, the hook's block is emitted as before, preserving v0.1 byte-for-byte behavior.
- `vault-doctor.sh` now reports which template is in use (FR7).

## Spec

- Requirements: `specs/feature-make-distillation-template-configurable/requirements.md`
- Design: `specs/feature-make-distillation-template-configurable/design.md`
- Tasks: `specs/feature-make-distillation-template-configurable/tasks.md`
- BDD: `specs/feature-make-distillation-template-configurable/feature.gherkin`

## Acceptance Criteria

- [x] AC1 — `distill.template_path` in config overrides the default prompt template
- [x] AC2 — Default behavior unchanged when `distill.template_path` is absent
- [x] AC3 — Missing/unreadable template falls back to default with stderr log (no crash)
- [x] AC4 — Only whitelisted `{{variables}}` are substituted; `$VAR`, backticks, `$(cmd)` are never expanded
- [x] AC5 — Custom YAML frontmatter from the template is preserved verbatim (beyond whitelisted variable substitution) at the top of the output

## Test Plan

- [ ] Run `tests/features/steps/distill.sh` — verify default output is byte-for-byte identical to v0.1 five-section layout
- [ ] Run `tests/unit/template.bats` — verify custom template path, variable substitution, missing-file fallback, and frontmatter passthrough
- [ ] Run `tests/unit/default-template.bats` — verify explicit `template_path` pointing at the bundled default matches unset behavior
- [ ] Run `tests/features/make-distillation-template-configurable.sh` — BDD integration suite
- [ ] Verify `vault-doctor` output includes the active template path