### PR TITLE
feat: spec baseline and integration tests for RAG prompt injection hook (#10)

### DIFF
--- a/specs/feature-rag-prompt-injection/tasks.md
+++ b/specs/feature-rag-prompt-injection/tasks.md
@@ -15,7 +15,7 @@
 | Backend | 3 | [x] |
 | Frontend | 0 | N/A |
 | Integration | 1 | [x] |
-| Testing | 3 | [ ] (deferred to #1 bats-core harness) |
+| Testing | 3 | [x] |
 | Phase 6: Embedding Retrieval Swap (Issue #5) | 11 | [ ] |
 | **Total** | **19** | |
 
@@ -105,8 +105,6 @@ Retroactive task breakdown for the v0.1 baseline. Phase 6 (added by issue #5) sw
 
 ## Phase 5: BDD Testing (Required)
 
-> Deferred until #1 lands the bats-core harness.
-
 ### T007: BDD feature file
 
 **File(s)**: `specs/feature-rag-prompt-injection/feature.gherkin`
@@ -120,15 +118,15 @@ Retroactive task breakdown for the v0.1 baseline. Phase 6 (added by issue #5) sw
 
 ### T008: Step definitions + integration tests
 
-**File(s)**: `tests/features/steps/vault-rag.sh`, `tests/integration/vault-rag.bats`
+**File(s)**: `tests/features/steps/rag.sh`, `tests/integration/vault-rag.bats`
 **Type**: Create
 **Depends**: T007, issue #1
 **Acceptance**:
-- [ ] Step definitions cover every Given/When/Then phrase used in the 12 scenarios
-- [ ] All filesystem state under `$BATS_TEST_TMPDIR`
-- [ ] Stubs `rg` path (unset `PATH`) to force the fallback in AC3
-- [ ] Seeds a 1,000-note fixture vault for performance assertions
-- [ ] Passes `bats tests/integration` and `tests/run-bdd.sh`
+- [x] Step definitions cover every Given/When/Then phrase used in the 12 scenarios
+- [x] All filesystem state under `$BATS_TEST_TMPDIR`
+- [x] Stubs `rg` path (unset `PATH`) to force the fallback in AC3
+- [x] Seeds a 1,000-note fixture vault for performance assertions (see T009)
+- [x] Passes `bats tests/integration` and `tests/run-bdd.sh`
 
 ### T009: Performance benchmark
 
@@ -136,9 +134,9 @@ Retroactive task breakdown for the v0.1 baseline. Phase 6 (added by issue #5) sw
 **Type**: Create
 **Depends**: T008, issue #1
 **Acceptance**:
-- [ ] Seeds 1,000-note vault, invokes hook 20× with varied prompts
-- [ ] Asserts p95 wall time < 300 ms (NFR)
-- [ ] Skippable via env var on slow CI runners
+- [x] Seeds 1,000-note vault, invokes hook 20× with varied prompts
+- [x] Asserts p95 wall time < 300 ms (NFR)
+- [x] Skippable via env var on slow CI runners
 
 ---
 
@@ -321,6 +319,7 @@ All Phase 6 tasks are blocked by #1 (bats-core harness).
 |-------|------|---------|
 | #10 | 2026-04-19 | Initial baseline task breakdown — documents v0.1.0 shipped implementation; testing phase deferred to #1 |
 | #5 | 2026-04-21 | Added Phase 6: extract keyword logic (T010), convert `vault-rag.sh` into a dispatcher (T011), implement embedding backend (T012) + reindex (T013) + reindex skill (T014), wire config into setup (T015) and doctor (T016), update `steering/tech.md` (T017), and add BDD + integration coverage (T018–T020). All Phase 6 tasks blocked by #1. |
+| #10 | 2026-04-22 | Landed Phase 5 testing (T008, T009) against the now-available bats-core harness: `tests/integration/vault-rag.bats` covers AC1–AC12 end-to-end, `tests/integration/vault-rag-perf.bats` enforces the <300 ms p95 NFR on a 1 000-note vault (skippable via `OBM_SKIP_PERF=1`). |
 
 ---
 

--- a/tests/integration/vault-rag-perf.bats
+++ b/tests/integration/vault-rag-perf.bats
@@ -9,11 +9,13 @@
 # `rg` fast-path is unavailable.
 
 setup() {
+  # Load before the skip check so teardown's assert_home_untouched is defined
+  # on the skipped path — bats runs teardown regardless of skip.
+  load '../helpers/scratch'
+
   if [ "${OBM_SKIP_PERF:-0}" = 1 ]; then
     skip "OBM_SKIP_PERF=1 set"
   fi
-
-  load '../helpers/scratch'
 
   RAG="$PLUGIN_ROOT/scripts/vault-rag.sh"
   CONFIG="$HOME/.claude/obsidian-memory/config.json"
@@ -22,6 +24,13 @@ setup() {
   mkdir -p "$HOME/.claude/obsidian-memory" "$HOME/.claude/projects"
   mkdir -p "$VAULT/claude-memory/sessions"
   ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+
+  if date +%s%N 2>/dev/null | grep -qE '^[0-9]{13,}$'; then
+    HAS_GNU_DATE=1
+  else
+    HAS_GNU_DATE=0
+  fi
+  export HAS_GNU_DATE
 
   cat > "$CONFIG" <<EOF
 {
@@ -41,10 +50,9 @@ _seed_1000_notes() {
   local words=(alpha bravo charlie delta eecho foxtrot golfo hotel india juliet \
                kilotango limat mikes november oscar papayas quebec romeos sierra tangos)
   local i wi line
-  for i in $(seq 1 1000); do
+  for i in {1..1000}; do
     wi=$(( i % 20 ))
     line="${words[$wi]} is the topic of note number $i here"
-    # ~1 KB body with mild variation across lines.
     {
       printf '%s\n' "$line"
       printf '%s\n' "$line"
@@ -56,14 +64,13 @@ _seed_1000_notes() {
 }
 
 _elapsed_ms() {
-  # Millisecond wall time for one hook invocation. Prefers GNU date's
-  # %s%N (Linux + modern macOS coreutils) for ns precision; falls back
-  # to python3 time.perf_counter on environments where %N is literal.
+  # Falls back to python3 time.perf_counter when GNU date %s%N is unavailable
+  # (HAS_GNU_DATE cached once in setup to avoid per-call subprocess overhead).
   local prompt="$1"
   local payload
   payload="$(jq -n --arg p "$prompt" '{prompt:$p}')"
 
-  if date +%s%N 2>/dev/null | grep -qE '^[0-9]{13,}$'; then
+  if [ "${HAS_GNU_DATE:-0}" = 1 ]; then
     local start end
     start="$(date +%s%N)"
     printf '%s' "$payload" | "$RAG" >/dev/null

--- a/tests/integration/vault-rag-perf.bats
+++ b/tests/integration/vault-rag-perf.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+
+# tests/integration/vault-rag-perf.bats — performance benchmark for the
+# UserPromptSubmit hook. Validates the <300 ms p95 wall-time NFR from
+# specs/feature-rag-prompt-injection/requirements.md on a synthetic
+# 1,000-note vault.
+#
+# Skip via OBM_SKIP_PERF=1 on slow CI runners or dev machines where the
+# `rg` fast-path is unavailable.
+
+setup() {
+  if [ "${OBM_SKIP_PERF:-0}" = 1 ]; then
+    skip "OBM_SKIP_PERF=1 set"
+  fi
+
+  load '../helpers/scratch'
+
+  RAG="$PLUGIN_ROOT/scripts/vault-rag.sh"
+  CONFIG="$HOME/.claude/obsidian-memory/config.json"
+  export RAG CONFIG
+
+  mkdir -p "$HOME/.claude/obsidian-memory" "$HOME/.claude/projects"
+  mkdir -p "$VAULT/claude-memory/sessions"
+  ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+
+  cat > "$CONFIG" <<EOF
+{
+  "vaultPath": "$VAULT",
+  "rag": { "enabled": true },
+  "distill": { "enabled": true }
+}
+EOF
+}
+
+teardown() { assert_home_untouched; }
+
+_seed_1000_notes() {
+  # Deterministic fixture: 1000 notes each ~1 KB with a rotating
+  # 20-word vocabulary so ~1/20 of the notes match any given prompt
+  # keyword — realistic recall pressure for the scorer.
+  local words=(alpha bravo charlie delta eecho foxtrot golfo hotel india juliet \
+               kilotango limat mikes november oscar papayas quebec romeos sierra tangos)
+  local i wi line
+  for i in $(seq 1 1000); do
+    wi=$(( i % 20 ))
+    line="${words[$wi]} is the topic of note number $i here"
+    # ~1 KB body with mild variation across lines.
+    {
+      printf '%s\n' "$line"
+      printf '%s\n' "$line"
+      printf '%s\n' "$line"
+      printf '%s padding line for slightly larger notes\n' "${words[$(( (wi + 3) % 20 ))]}"
+      printf '%s padding line for slightly larger notes\n' "${words[$(( (wi + 7) % 20 ))]}"
+    } > "$VAULT/note-$(printf '%04d' "$i").md"
+  done
+}
+
+_elapsed_ms() {
+  # Millisecond wall time for one hook invocation. Prefers GNU date's
+  # %s%N (Linux + modern macOS coreutils) for ns precision; falls back
+  # to python3 time.perf_counter on environments where %N is literal.
+  local prompt="$1"
+  local payload
+  payload="$(jq -n --arg p "$prompt" '{prompt:$p}')"
+
+  if date +%s%N 2>/dev/null | grep -qE '^[0-9]{13,}$'; then
+    local start end
+    start="$(date +%s%N)"
+    printf '%s' "$payload" | "$RAG" >/dev/null
+    end="$(date +%s%N)"
+    printf '%d\n' $(( (end - start) / 1000000 ))
+    return 0
+  fi
+
+  python3 - "$RAG" <<'PY' "$payload"
+import subprocess, sys, time
+rag, payload = sys.argv[1], sys.argv[2]
+t0 = time.perf_counter()
+subprocess.run([rag], input=payload.encode(), stdout=subprocess.DEVNULL, check=False)
+t1 = time.perf_counter()
+print(int((t1 - t0) * 1000))
+PY
+}
+
+@test "perf: p95 hook wall time < 300ms on a 1000-note vault" {
+  _seed_1000_notes
+
+  local prompts=(
+    "alpha something useful"
+    "bravo details about the topic"
+    "charlie related content search"
+    "delta follow-up inquiry"
+    "eecho contextual request"
+    "foxtrot historical reference"
+    "golfo ancillary query"
+    "hotel cross-reference check"
+    "india descriptive search"
+    "juliet lookup attempt"
+    "kilotango background context"
+    "limat tangential query"
+    "mikes recurring topic"
+    "november supplementary info"
+    "oscar expanded context"
+    "papayas latest notes"
+    "quebec related work"
+    "romeos prior discussion"
+    "sierra design notes"
+    "tangos implementation detail"
+  )
+
+  local ms times=()
+  local p
+  for p in "${prompts[@]}"; do
+    ms="$(_elapsed_ms "$p")"
+    times+=("$ms")
+  done
+
+  local sorted p95 p95_idx
+  sorted="$(printf '%s\n' "${times[@]}" | sort -n)"
+  # Ceiling of N * 0.95 — 19th of 20 samples, 10th of 10, etc.
+  p95_idx=$(( (${#times[@]} * 95 + 99) / 100 ))
+  p95="$(printf '%s\n' "$sorted" | sed -n "${p95_idx}p")"
+
+  printf 'vault-rag p95 over %d samples: %s ms\n' "${#times[@]}" "$p95" >&3
+  printf 'samples (sorted asc): %s\n' "$(printf '%s\n' "$sorted" | tr '\n' ' ')" >&3
+
+  [ "$p95" -lt 300 ]
+}

--- a/tests/integration/vault-rag.bats
+++ b/tests/integration/vault-rag.bats
@@ -90,7 +90,7 @@ _seed_note() {
   _seed_note "my-note.md" "ripgrep not needed when grep is present"
 
   hide_binary rg
-  ! command -v rg >/dev/null 2>&1
+  [ -z "$(command -v rg)" ]
 
   run _run_rag "ripgrep fallback"
 
@@ -148,7 +148,7 @@ _seed_note() {
   _seed_note "my-note.md" "jq is used for config parsing"
 
   hide_binary jq
-  ! command -v jq >/dev/null 2>&1
+  [ -z "$(command -v jq)" ]
 
   # No jq means we cannot build the JSON payload with jq -n; hand-craft it.
   run bash -c 'printf "%s" "{\"prompt\":\"jq config parsing\"}" | "$0"' "$RAG"
@@ -192,7 +192,6 @@ _seed_note() {
   [ "$status" -eq 0 ]
   [[ "$output" == *'<vault-context source="obsidian"'* ]]
 
-  # Extract keywords="kw1,kw2,..." and count comma-separated entries.
   local kw_attr count
   kw_attr="$(printf '%s' "$output" | sed -nE 's/.*keywords="([^"]*)".*/\1/p' | head -n 1)"
   [ -n "$kw_attr" ]
@@ -206,13 +205,14 @@ _seed_note() {
   _write_config
   local kw="sharedkeyword"
   local i n
-  for i in 1 2 3 4 5 6 7 8 9 10; do
-    : > "$VAULT/note-$i.md"
-    n="$i"
-    while [ "$n" -gt 0 ]; do
-      printf '%s line %d\n' "$kw" "$n" >> "$VAULT/note-$i.md"
-      n=$((n - 1))
-    done
+  for i in {1..10}; do
+    {
+      n="$i"
+      while [ "$n" -gt 0 ]; do
+        printf '%s line %d\n' "$kw" "$n"
+        n=$((n - 1))
+      done
+    } > "$VAULT/note-$i.md"
   done
 
   run _run_rag "$kw appears frequently"
@@ -243,6 +243,7 @@ _seed_note() {
   _write_config
   _seed_note "note.md" "safe keyword test content with injection filler"
 
+  # shellcheck disable=SC2016  # literal shell metacharacters are the test fixture
   local sneaky='$(whoami) ; rm -rf /  `echo x`  '\''injection'\''  "quote"  injection'
   local user_marker
   user_marker="$(id -un)"

--- a/tests/integration/vault-rag.bats
+++ b/tests/integration/vault-rag.bats
@@ -1,0 +1,260 @@
+#!/usr/bin/env bats
+
+# tests/integration/vault-rag.bats — end-to-end coverage of the
+# UserPromptSubmit hook (scripts/vault-rag.sh) for the v0.1.0 keyword backend.
+# Each @test exercises one acceptance criterion (AC1–AC12) from
+# specs/feature-rag-prompt-injection/requirements.md. With no `rag.backend`
+# key in config the dispatcher delegates to vault-rag-keyword.sh unchanged.
+
+setup() {
+  load '../helpers/scratch'
+
+  RAG="$PLUGIN_ROOT/scripts/vault-rag.sh"
+  CONFIG="$HOME/.claude/obsidian-memory/config.json"
+  export RAG CONFIG
+
+  mkdir -p "$HOME/.claude/obsidian-memory" "$HOME/.claude/projects"
+  mkdir -p "$VAULT/claude-memory/sessions"
+  ln -sfn "$HOME/.claude/projects" "$VAULT/claude-memory/projects"
+
+  HELPERS_DIR="$PLUGIN_ROOT/tests/helpers"
+  export HELPERS_DIR
+  # shellcheck disable=SC1091
+  . "$PLUGIN_ROOT/tests/features/steps/common.sh"
+}
+
+teardown() { assert_home_untouched; }
+
+_write_config() {
+  # $1 = optional jq filter applied to a permissive v0.1 baseline config.
+  local filter="${1:-.}"
+  cat > "$CONFIG" <<EOF
+{
+  "vaultPath": "$VAULT",
+  "rag": { "enabled": true },
+  "distill": { "enabled": true }
+}
+EOF
+  if [ "$filter" != "." ]; then
+    local tmp
+    tmp="$(mktemp "$BATS_TEST_TMPDIR/cfg.XXXXXX")"
+    jq --indent 2 "$filter" "$CONFIG" > "$tmp" && mv "$tmp" "$CONFIG"
+  fi
+}
+
+_run_rag() {
+  # $1 = prompt string
+  local payload
+  payload="$(jq -n --arg p "$1" '{prompt:$p}')"
+  printf '%s' "$payload" | "$RAG"
+}
+
+_seed_note() {
+  # $1 = relative path under $VAULT, $2 = body
+  local rel="$1" body="$2"
+  mkdir -p "$(dirname "$VAULT/$rel")"
+  printf '%s\n' "$body" > "$VAULT/$rel"
+}
+
+# --- AC1: vault note contains a keyword from the prompt --------------------
+
+@test "AC1: keyword match emits a <vault-context> block listing the note and excerpt" {
+  _write_config
+  _seed_note "my-note.md" "jq is used for config parsing"
+
+  run _run_rag "How do I use jq for config parsing?"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'<vault-context source="obsidian"'* ]]
+  [[ "$output" == *"my-note.md"* ]]
+  [[ "$output" == *"jq is used for config parsing"* ]]
+  [[ "$output" == *"</vault-context>"* ]]
+}
+
+# --- AC2: no matching notes --------------------------------------------------
+
+@test "AC2: no matching vault notes produces empty stdout and exit 0" {
+  _write_config
+  _seed_note "unrelated.md" "just some static words about planets and oceans"
+
+  run _run_rag "completely disjoint prompt about magnetism"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"<vault-context"* ]]
+}
+
+# --- AC3: rg not on PATH — POSIX fallback -----------------------------------
+
+@test "AC3: hook still emits a block when rg is not on PATH (POSIX fallback)" {
+  _write_config
+  _seed_note "my-note.md" "ripgrep not needed when grep is present"
+
+  hide_binary rg
+  ! command -v rg >/dev/null 2>&1
+
+  run _run_rag "ripgrep fallback"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'<vault-context source="obsidian"'* ]]
+  [[ "$output" == *"my-note.md"* ]]
+}
+
+# --- AC4: RAG disabled via config flag --------------------------------------
+
+@test "AC4: rag.enabled=false produces empty stdout without reading the vault" {
+  _write_config '.rag.enabled = false'
+  _seed_note "my-note.md" "jq is used for config parsing"
+
+  run _run_rag "jq config parsing"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- AC5: auto-memory symlink path is excluded (feedback-loop guard) --------
+
+@test "AC5: matches under claude-memory/projects/** are excluded" {
+  _write_config
+  # The setup above pointed $VAULT/claude-memory/projects at $HOME/.claude/projects.
+  # Seed a JSONL transcript under that symlinked tree — it must NOT match.
+  mkdir -p "$HOME/.claude/projects/some-project"
+  printf '%s\n' "jq appears here in a transcript line" \
+    > "$HOME/.claude/projects/some-project/2026-04-18.jsonl"
+
+  run _run_rag "jq config parsing"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"<vault-context"* ]]
+}
+
+# --- AC6: Obsidian metadata directories are excluded ------------------------
+
+@test "AC6: .obsidian/ and .trash/ are excluded from scoring" {
+  _write_config
+  mkdir -p "$VAULT/.obsidian" "$VAULT/.trash"
+  printf 'ripgrep appears in workspace metadata\n' > "$VAULT/.obsidian/workspace.json"
+  printf 'ripgrep appears in a deleted note\n' > "$VAULT/.trash/deleted-note.md"
+
+  run _run_rag "ripgrep metadata"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"<vault-context"* ]]
+}
+
+# --- AC7: missing jq dependency ---------------------------------------------
+
+@test "AC7: missing jq exits 0 silently and delivers the prompt unchanged" {
+  _write_config
+  _seed_note "my-note.md" "jq is used for config parsing"
+
+  hide_binary jq
+  ! command -v jq >/dev/null 2>&1
+
+  # No jq means we cannot build the JSON payload with jq -n; hand-craft it.
+  run bash -c 'printf "%s" "{\"prompt\":\"jq config parsing\"}" | "$0"' "$RAG"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- AC8: missing config file -----------------------------------------------
+
+@test "AC8: missing config.json exits 0 silently" {
+  [ ! -e "$CONFIG" ]
+
+  run _run_rag "anything"
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- AC9: stopwords-only prompt emits no block ------------------------------
+
+@test "AC9: all-stopword prompt produces no <vault-context> block" {
+  _write_config
+  _seed_note "anything.md" "the and for with that this from have"
+
+  run _run_rag "the and for with that this from have"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"<vault-context"* ]]
+}
+
+# --- AC10: keyword cap of 6 is enforced -------------------------------------
+
+@test "AC10: 20-token prompt is capped to 6 keywords in the output attribute" {
+  _write_config
+  local twenty="alpha bravo charlie delta eecho foxtrot golfo hotel india juliet kilotango limat mikes november oscar papayas quebec romeos sierra tangos"
+  _seed_note "tokens.md" "$twenty"
+
+  run _run_rag "$twenty"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'<vault-context source="obsidian"'* ]]
+
+  # Extract keywords="kw1,kw2,..." and count comma-separated entries.
+  local kw_attr count
+  kw_attr="$(printf '%s' "$output" | sed -nE 's/.*keywords="([^"]*)".*/\1/p' | head -n 1)"
+  [ -n "$kw_attr" ]
+  count="$(printf '%s' "$kw_attr" | tr ',' '\n' | grep -c .)"
+  [ "$count" -le 6 ]
+}
+
+# --- AC11: top-5 ranking and excerpt format ---------------------------------
+
+@test "AC11: top-5 ordered by descending hit count, with ### header + fenced excerpt" {
+  _write_config
+  local kw="sharedkeyword"
+  local i n
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    : > "$VAULT/note-$i.md"
+    n="$i"
+    while [ "$n" -gt 0 ]; do
+      printf '%s line %d\n' "$kw" "$n" >> "$VAULT/note-$i.md"
+      n=$((n - 1))
+    done
+  done
+
+  run _run_rag "$kw appears frequently"
+
+  [ "$status" -eq 0 ]
+
+  # Exactly five "### note-*.md" headers.
+  local header_count
+  header_count="$(printf '%s\n' "$output" | grep -Ec '^### note-.*\.md  \(hits: [0-9]+\)$')"
+  [ "$header_count" -eq 5 ]
+
+  # Each excerpt is fenced with ``` — open/close counts even, >= 10 (5 notes * 2).
+  local fence_count
+  fence_count="$(printf '%s\n' "$output" | grep -c '^```$')"
+  [ "$fence_count" -ge 10 ]
+  [ $((fence_count % 2)) -eq 0 ]
+
+  # Hit counts appear in descending order (10, 9, 8, 7, 6).
+  local hits_list expected
+  hits_list="$(printf '%s\n' "$output" | sed -nE 's/^### note-[0-9]+\.md  \(hits: ([0-9]+)\)$/\1/p')"
+  expected="$(printf '10\n9\n8\n7\n6\n')"
+  [ "$hits_list" = "$expected" ]
+}
+
+# --- AC12: prompt-injection safety -------------------------------------------
+
+@test "AC12: shell metacharacters in the prompt never spawn a subshell" {
+  _write_config
+  _seed_note "note.md" "safe keyword test content with injection filler"
+
+  local sneaky='$(whoami) ; rm -rf /  `echo x`  '\''injection'\''  "quote"  injection'
+  local user_marker
+  user_marker="$(id -un)"
+  run _run_rag "$sneaky"
+
+  [ "$status" -eq 0 ]
+  # Command substitution would surface the current username in the output.
+  [[ "$output" != *"$user_marker"* ]]
+  # The keywords attribute, if emitted, must contain only alphanumeric tokens.
+  local kw_attr
+  kw_attr="$(printf '%s' "$output" | sed -nE 's/.*keywords="([^"]*)".*/\1/p' | head -n 1)"
+  if [ -n "$kw_attr" ]; then
+    printf '%s' "$kw_attr" | grep -Ev '[`;$\\]' >/dev/null
+  fi
+}


### PR DESCRIPTION
## Summary

- Closes #10 — retroactive spec baseline for the `UserPromptSubmit → vault-rag.sh` hook (shipped in v0.1.0)
- Adds `tests/integration/vault-rag.bats` covering AC1–AC12 end-to-end (keyword path, POSIX fallback, exclusions, prompt-injection safety)
- Adds `tests/integration/vault-rag-perf.bats` enforcing the <300 ms p95 NFR on a 1,000-note vault (skippable via `OBM_SKIP_PERF=1`)

## Spec

**[specs/feature-rag-prompt-injection/requirements.md](specs/feature-rag-prompt-injection/requirements.md)**
**[specs/feature-rag-prompt-injection/tasks.md](specs/feature-rag-prompt-injection/tasks.md)**

## Acceptance Criteria (from spec)

- [ ] AC1: Vault note keyword match emits `<vault-context>` block
- [ ] AC2: No matching notes — hook exits 0 with no output
- [ ] AC3: `rg` absent — POSIX fallback produces same output
- [ ] AC4: `rag.enabled=false` — no output, exit 0
- [ ] AC5: `claude-memory/projects/**` files excluded from results
- [ ] AC6: `.obsidian/**` and `.trash/**` excluded
- [ ] AC7: Missing `jq` — exit 0, no output
- [ ] AC8: Missing config — exit 0, no output
- [ ] AC9: All-stopword prompt — no output, exit 0
- [ ] AC10: Keyword cap of 6 enforced
- [ ] AC11: Top-5 ranking, correct excerpt format
- [ ] AC12: Shell metacharacters in prompt — no subshell spawned, exit 0

## Test plan

- [ ] `bats tests/integration/vault-rag.bats` passes all 12 scenarios
- [ ] `bats tests/integration/vault-rag-perf.bats` passes (or skip with `OBM_SKIP_PERF=1` on slow runners)
- [ ] No regressions in existing integration tests (`bats tests/integration`)